### PR TITLE
Add a Python tool for LLM-chain.

### DIFF
--- a/llm-chain-tools/src/tool_prompt_prefix.txt
+++ b/llm-chain-tools/src/tool_prompt_prefix.txt
@@ -1,4 +1,4 @@
-You are now entering command only mode. You may only respond with YAML. You provided with tools that you can invoke by naming the tool you wish to invoke along with it's input.
+You are now entering command-only mode. You may only respond with YAML. You are provided with tools that you can invoke by naming the tool you wish to invoke along with it's input.
 
 To invoke a tool write YAML like this, do not include output:
 command: Command

--- a/llm-chain-tools/src/tools/mod.rs
+++ b/llm-chain-tools/src/tools/mod.rs
@@ -3,5 +3,7 @@
 
 mod bash;
 mod exit;
+mod python;
 pub use bash::BashTool;
 pub use exit::ExitTool;
+pub use python::PythonTool;

--- a/llm-chain-tools/src/tools/python.rs
+++ b/llm-chain-tools/src/tools/python.rs
@@ -1,0 +1,66 @@
+use crate::description::{Describe, Format, ToolDescription};
+use crate::tool::{gen_invoke_function, Tool};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+pub struct PythonTool {}
+
+impl PythonTool {
+    pub fn new() -> Self {
+        PythonTool {}
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PythonToolInput {
+    code: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PythonToolOutput {
+    result: String,
+    stderr: String,
+}
+
+impl Describe for PythonToolInput {
+    fn describe() -> Format {
+        vec![("code", "The Python code to execute.").into()].into()
+    }
+}
+
+impl Describe for PythonToolOutput {
+    fn describe() -> Format {
+        vec![
+            ("result", "The result of the executed Python code.").into(),
+            ("stderr", "The stderr output of the Python code execution.").into(),
+        ]
+        .into()
+    }
+}
+
+impl PythonTool {
+    fn invoke_typed(&self, input: &PythonToolInput) -> Result<PythonToolOutput, String> {
+        let output = Command::new("python3")
+            .arg("-c")
+            .arg(&input.code)
+            .output()
+            .map_err(|_e| "failed to execute process")?;
+        Ok(PythonToolOutput {
+            result: String::from_utf8(output.stdout).unwrap(),
+            stderr: String::from_utf8(output.stderr).unwrap(),
+        })
+    }
+}
+
+impl Tool for PythonTool {
+    gen_invoke_function!();
+    fn description(&self) -> ToolDescription {
+        ToolDescription::new(
+            "PythonTool",
+            "A tool that executes Python code.",
+            "Use this to execute Python code to solve your goals",
+            PythonToolInput::describe(),
+            PythonToolOutput::describe(),
+        )
+    }
+}


### PR DESCRIPTION
This tool is a simple wrapper around the Python interpreter. It invokes
Python code and returns the result. The Python code is passed as a string
to the Python interpreter and is executed using `python3 -c`
