### PR TITLE
feat: Separate the output into its own trait.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 model.bin
 .vscode/
 build/
+chain
+mydata.yaml

--- a/llm-chain-llama/src/executor.rs
+++ b/llm-chain-llama/src/executor.rs
@@ -148,17 +148,6 @@ impl ExecutorTrait for Executor {
     ) -> Self::Output {
         self.run_model(input)
     }
-
-    // Applies the output to the given parameters.
-    fn apply_output_to_parameters(parameters: Parameters, output: &Self::Output) -> Parameters {
-        parameters.with_text(output.to_owned())
-    }
-
-    // Combines two outputs into a single output.
-    fn combine_outputs(output: &Self::Output, other: &Self::Output) -> Self::Output {
-        output.combine(other)
-    }
-
     fn tokens_used(
         &self,
         step: &LLamaStep,

--- a/llm-chain-llama/src/output.rs
+++ b/llm-chain-llama/src/output.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+use llm_chain::output;
 use std::fmt::{Display, Formatter};
 
 /// Represents the output from the LLAMA model.
@@ -64,5 +66,12 @@ impl From<&str> for Output {
 impl From<Output> for Box<str> {
     fn from(output: Output) -> Self {
         output.output.into_boxed_str()
+    }
+}
+
+#[async_trait]
+impl output::Output for Output {
+    async fn primary_textual_output_choices(&self) -> Vec<String> {
+        vec![self.output.clone()]
     }
 }

--- a/llm-chain-openai/src/chatgpt/mod.rs
+++ b/llm-chain-openai/src/chatgpt/mod.rs
@@ -1,9 +1,11 @@
 //! This module implements chains for the ChatGPT model from OpenAI.
 mod executor;
+mod output;
 mod prompt;
 mod step;
 
 pub use async_openai::types::Role;
 pub use executor::Executor;
+pub use output::Output;
 pub use prompt::{ChatPromptTemplate, MessagePromptTemplate};
 pub use step::{Model, Step};

--- a/llm-chain-openai/src/chatgpt/output.rs
+++ b/llm-chain-openai/src/chatgpt/output.rs
@@ -1,0 +1,64 @@
+//! # Output Module
+//!
+//! This module provides an implementation of the `Output` trait for the
+//! `CreateChatCompletionResponse` from ChatGPT's API
+//!
+//! The `Output` struct wraps the response, and provides human-readable
+//! representation and easy access to the output choices.
+//!
+//! ## Example
+//!
+//! ```rust
+//! use async_openai::types::CreateChatCompletionResponse;
+//! use llm_chain::output::Output;
+//! use llm_chain_openai::chatgpt::Output as OpenAIOutput;
+//!
+//! fn handle_response(response: CreateChatCompletionResponse) {
+//!     let output: OpenAIOutput = response.into();
+//!     println!("Chat message: {}", output);
+//! }
+//! ```
+//!
+use async_trait::async_trait;
+use std::{fmt, ops::Deref};
+
+use async_openai::types::CreateChatCompletionResponse;
+use llm_chain::output;
+
+/// Represents the output of a CreateChatCompletionResponse from OpenAI.
+#[derive(Clone, Debug)]
+pub struct Output(CreateChatCompletionResponse);
+
+/// Implement the Display trait to provide a human-readable representation of the Output.
+impl fmt::Display for Output {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.choices[0].message.content)
+    }
+}
+
+/// Implement the Output trait required for LLM outputs
+#[async_trait]
+impl output::Output for Output {
+    async fn primary_textual_output_choices(&self) -> Vec<String> {
+        self.0
+            .choices
+            .iter()
+            .map(|choice| choice.message.content.clone())
+            .collect()
+    }
+}
+
+/// Implement the Deref trait to provide access to the underlying CreateChatCompletionResponse.
+impl Deref for Output {
+    type Target = CreateChatCompletionResponse;
+    fn deref(&self) -> &CreateChatCompletionResponse {
+        &self.0
+    }
+}
+
+/// Implement From trait to allow conversion from CreateChatCompletionResponse to Output.
+impl From<CreateChatCompletionResponse> for Output {
+    fn from(response: CreateChatCompletionResponse) -> Self {
+        Self(response)
+    }
+}

--- a/llm-chain/Cargo.toml
+++ b/llm-chain/Cargo.toml
@@ -19,6 +19,7 @@ async = ["dep:tokio"]
 async-trait = "0.1.67"
 dynfmt = { version = "0.1.5", features = ["curly"], default-features = false }
 futures = "0.3.27"
+pulldown-cmark = "0.9.2"
 serde = { version = "1.0.159", optional = true, features = ["derive"] }
 serde_yaml = { version = "0.9.21", optional = true }
 thiserror = "1.0.40"

--- a/llm-chain/src/chains/sequential.rs
+++ b/llm-chain/src/chains/sequential.rs
@@ -31,7 +31,8 @@ impl<S: Step> Chain<S> {
         for step in self.steps.iter() {
             let frame = Frame::new(executor, step);
             let res = frame.format_and_execute(&current_params).await;
-            current_params = E::apply_output_to_parameters(current_params, &res);
+
+            current_params = current_params.with_text_from_output(&res).await;
             output = Some(res);
         }
         output

--- a/llm-chain/src/lib.rs
+++ b/llm-chain/src/lib.rs
@@ -27,6 +27,8 @@ pub mod frame;
 
 pub mod tokens;
 
+pub mod output;
+
 pub use parameters::Parameters;
 
 pub use templates::PromptTemplate;

--- a/llm-chain/src/output.rs
+++ b/llm-chain/src/output.rs
@@ -1,0 +1,55 @@
+use async_trait::async_trait;
+use futures::stream::StreamExt;
+
+/// Separator string used when joining primary textual outputs.
+const OUTPUT_JOINER_SEQUENCE: &str = "\n";
+
+/// The `Output` trait represents the output of a Large Language Model (LLM). It provides
+/// methods for retrieving and combining textual outputs from different models.
+#[async_trait]
+pub trait Output: Send + Clone + Sync {
+    /// Gets the primary textual output of the model. This method returns a vector of strings
+    /// containing zero to many outputs depending on how many "choices" were generated.
+    async fn primary_textual_output_choices(&self) -> Vec<String>;
+
+    /// Gets the primary textual output of the model, if any. If there are multiple choices,
+    /// it returns the first one. If no choices are available, it returns `None`.
+    async fn primary_textual_output(&self) -> Option<String> {
+        let outputs = self.primary_textual_output_choices().await;
+        if outputs.is_empty() {
+            None
+        } else {
+            Some(outputs[0].clone())
+        }
+    }
+
+    /// Combines the primary textual outputs from multiple instances implementing the `Output` trait.
+    /// The outputs are joined using the `OUTPUT_JOINER_SEQUENCE` separator.
+    async fn combine_primary_textual_outputs(outputs: &[&Self]) -> String {
+        let primary_outputs = futures::stream::iter(outputs)
+            .then(|output| output.primary_textual_output())
+            .filter_map(|opt_output| async move { opt_output })
+            .collect::<Vec<String>>()
+            .await;
+
+        primary_outputs.join(OUTPUT_JOINER_SEQUENCE)
+    }
+
+    /// Combines the primary textual outputs of a pair of instances implementing the `Output` trait.
+    /// The outputs are joined using the `OUTPUT_JOINER_SEQUENCE` separator.
+    async fn combine_primary_textual_outputs_for_pair(output1: &Self, output2: &Self) -> String {
+        let (output1, output2) = futures::join!(
+            output1.primary_textual_output(),
+            output2.primary_textual_output()
+        );
+
+        match (output1, output2) {
+            (Some(output1), Some(output2)) => {
+                format!("{}{}{}", output1, OUTPUT_JOINER_SEQUENCE, output2)
+            }
+            (Some(output1), None) => output1,
+            (None, Some(output2)) => output2,
+            (None, None) => String::new(),
+        }
+    }
+}

--- a/llm-chain/src/parameters.rs
+++ b/llm-chain/src/parameters.rs
@@ -1,6 +1,8 @@
 use dynfmt::{Argument, FormatArgs};
 use std::collections::HashMap;
 
+use crate::output::Output;
+
 /// Parameters define the parameters sent into each step. The parameters are used to fill in the prompt template, and are also filled in by the output of the previous step. Parameters have a special key, `text`, which is used as a default key for simple use cases.
 ///
 /// Parameters also implement a few convenience conversion traits to make it easier to work with them.
@@ -77,6 +79,12 @@ impl Parameters {
     /// Copies the parameters and adds a new key-value pair with the key `text`, which is the default key.
     pub fn with_text<K: Into<String>>(&self, text: K) -> Parameters {
         self.with(TEXT_KEY, text)
+    }
+    pub async fn with_text_from_output<O: Output>(&self, output: &O) -> Parameters {
+        output
+            .primary_textual_output()
+            .await
+            .map_or(self.clone(), |text| self.with_text(text))
     }
     /// Combines two sets of parameters, returning a new set of parameters with all the keys from both sets.
     pub fn combine(&self, other: &Parameters) -> Parameters {

--- a/llm-chain/src/templates.rs
+++ b/llm-chain/src/templates.rs
@@ -36,9 +36,9 @@ pub struct PromptTemplate {
 impl PromptTemplate {
     /// Create a new prompt template from a string.
     pub fn new<K: Into<String>>(template: K) -> PromptTemplate {
-      PromptTemplate {
-        template: template.into()
-      }
+        PromptTemplate {
+            template: template.into(),
+        }
     }
     /// Format the template with the given parameters.
     pub fn format(&self, parameters: &Parameters) -> String {
@@ -52,7 +52,7 @@ impl PromptTemplate {
 
 impl<T: Into<String>> From<T> for PromptTemplate {
     fn from(template: T) -> Self {
-        Self::new(&template.into())
+        Self::new(template.into())
     }
 }
 

--- a/llm-chain/src/traits.rs
+++ b/llm-chain/src/traits.rs
@@ -1,26 +1,51 @@
-//! Welcome to the `traits` module! This is where llm-chain houses its public traits, which define the essential behavior of steps and executors. These traits are the backbone of our library and are used to implement a new model.
+//! # Traits Module
 //!
-//! Let's break it down:
-//! - **Steps**: These are the building blocks that make up the chains. Steps define the parameters, including the prompt that is sent to the LLM.
-//! - **Executors**: These are the workhorses that perform the steps. They take the output of a step and invokes the model on it to get the output.
+//! Welcome to the `traits` module! This is where llm-chain houses its public traits, which define the essential behavior of steps and executors. These traits are the backbone of our library, and they provide the foundation for creating and working with different models in llm-chain.
 //!
-//! By implementing these traits, you can set up a new model and use it in your application. Your step, defines the input to the model, and your executor invokes the model and returns the output. The output of the executor is then passed to the next step in the chain, and so on.
+//! Here's a brief overview of the key concepts:
+//! - **Steps**: These are the building blocks that make up the chains. Steps define the parameters, including the prompt that is sent to the LLM (Large Language Model).
+//! - **Executors**: These are responsible for performing the steps. They take the output of a step, invoke the model with that input, and return the resulting output.
+//!
+//! By implementing these traits, you can set up a new model and use it in your application. Your step defines the input to the model, and your executor invokes the model and returns the output. The output of the executor is then passed to the next step in the chain, and so on.
+//!
 
 use crate::{
     chains::sequential,
+    output::Output,
     tokens::{PromptTokensError, TokenCount},
     Parameters,
 };
 use async_trait::async_trait;
 
-// A step is a single step in a chain. It takes a set of parameters and returns a formatted prompt that can be used by an executor.
+/// The `Step` trait represents a single step in a chain. It takes a set of parameters and returns a
+/// formatted prompt that can be used by an executor.
 pub trait Step {
+    /// The output type produced by this step.
     type Output: Send;
+
+    /// Formats the step given a set of parameters, returning a value that can be used by an
+    /// executor.
+    ///
+    /// # Parameters
+    ///
+    /// * `parameters`: The parameters used to format the step.
+    ///
+    /// # Returns
+    ///
+    /// The formatted output of this step.
     fn format(&self, parameters: &Parameters) -> Self::Output;
 }
 
 impl<T: ?Sized> StepExt for T where T: Step {}
+
+/// The `StepExt` trait extends the functionality of the `Step` trait, providing convenience
+/// methods for working with steps.
 pub trait StepExt: Step {
+    /// Converts this step into a sequential chain with a single step.
+    ///
+    /// # Returns
+    ///
+    /// A sequential chain containing this step.
     fn to_chain(self) -> sequential::Chain<Self>
     where
         Self: Sized,
@@ -30,35 +55,74 @@ pub trait StepExt: Step {
 }
 
 #[async_trait]
-// An executor performs a single step in a chain. It takes a step, executes it, and returns the output.
+/// The `Executor` trait represents an executor that performs a single step in a chain. It takes a
+/// step, executes it, and returns the output.
 pub trait Executor {
+    /// The step type that this executor works with.
     type Step: Step;
-    type Output: Send + Clone;
+
+    /// The output type produced by this executor.
+    type Output: Output;
+
+    /// The token type used by this executor.
     type Token;
+
+    /// Executes the given input and returns the resulting output.
+    ///
+    /// # Parameters
+    ///
+    /// * `input`: The input value to execute, that is the output of the step.
+    ///
+    /// # Returns
+    ///
+    /// The output produced by the executor.
     async fn execute(&self, input: <<Self as Executor>::Step as Step>::Output) -> Self::Output;
-    fn apply_output_to_parameters(parameters: Parameters, output: &Self::Output) -> Parameters;
-    fn combine_outputs(output: &Self::Output, other: &Self::Output) -> Self::Output;
-    fn combine_outputs_many(outputs: &[Self::Output]) -> Option<Self::Output> {
-        if outputs.is_empty() {
-            return None;
-        }
-        let (cur, rest) = outputs.split_first().unwrap();
-        let mut cur = cur.clone();
-        for output in rest {
-            cur = Self::combine_outputs(&cur, output);
-        }
-        Some(cur)
-    }
+
+    /// Calculates the number of tokens used by the step given a set of parameters.
+    ///
+    /// The step and the parameters together are used to form full prompt, which is then tokenized
+    /// and the token count is returned.
+    ///
+    /// # Parameters
+    ///
+    /// * `step`: The step to calculate token usage for.
+    /// * `parameters`: The parameters to plug into the step.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the token count, or an error if there was a problem.
     fn tokens_used(
         &self,
         step: &Self::Step,
         parameters: &Parameters,
     ) -> Result<TokenCount, PromptTokensError>;
+
+    /// Tokenizes a string based on the step.
+    ///
+    /// # Parameters
+    ///
+    /// * `step`: The step used for tokenization.
+    /// * `doc`: The string to tokenize.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a vector of tokens, or an error if there was a problem.
     fn tokenize_str(
         &self,
         step: &Self::Step,
         doc: &str,
     ) -> Result<Vec<Self::Token>, PromptTokensError>;
+
+    /// Converts a slice of tokens into a string based on the step.
+    ///
+    /// # Parameters
+    ///
+    /// * `step`: The step used for conversion.
+    /// * `tokens`: The slice of tokens to convert.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing a string, or an error if there was a problem.
     fn to_string(
         &self,
         step: &Self::Step,


### PR DESCRIPTION
By separating the output into its own trait we reduce the amount of
code that needs to be duplicated between the different models.

To accomplish this we made the assumption that models ought to return
strings in general. This is a reasonable assumption given what LLMs are.
