### PR TITLE
Feature: Similarity search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "tera",
  "thiserror",
  "tokio",
+ "tonic 0.9.1",
  "uuid",
 ]
 
@@ -1545,7 +1546,7 @@ dependencies = [
  "prost",
  "prost-types",
  "reqwest",
- "tonic",
+ "tonic 0.8.3",
  "tonic-build",
 ]
 
@@ -2207,6 +2208,34 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bd8e87955eb13c1986671838177d6792cdc52af9bffced0d2c8a9a7f741ab3"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/llm-chain-llama/examples/alpaca.rs
+++ b/llm-chain-llama/examples/alpaca.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &exec,
         )
         .await?;
-        
+
     println!("{:?}", res.to_string());
     Ok(())
 }

--- a/llm-chain-openai/examples/qdrant_vectorstore.rs
+++ b/llm-chain-openai/examples/qdrant_vectorstore.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use llm_chain::{traits::VectorStore, vectorstores::qdrant::Qdrant};
 use qdrant_client::{
     prelude::{QdrantClient, QdrantClientConfig},
-    qdrant::{CreateCollection, Distance, VectorParams, VectorsConfig, WithPayloadSelector},
+    qdrant::{CreateCollection, Distance, VectorParams, VectorsConfig},
 };
 
 #[tokio::main(flavor = "current_thread")]
@@ -41,7 +41,13 @@ async fn main() {
     let embeddings = llm_chain_openai::embeddings::Embeddings::default();
 
     // Storing documents
-    let qdrant = Qdrant::new(client.clone(), collection_name.clone(), embeddings);
+    let qdrant: Qdrant<llm_chain_openai::embeddings::Embeddings> = Qdrant::new(
+        client.clone(),
+        collection_name.clone(),
+        embeddings,
+        None,
+        None,
+    );
     let doc_ids = qdrant
         .add_texts(vec![
             "This is an amazing way of writing LLM-powered applications".to_string(),
@@ -56,7 +62,7 @@ async fn main() {
             collection_name,
             &doc_ids.into_iter().map(|id| id.into()).collect(),
             Some(true),
-            None::<WithPayloadSelector>,
+            Some(true),
             None,
         )
         .await

--- a/llm-chain-openai/examples/similarity_search.rs
+++ b/llm-chain-openai/examples/similarity_search.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use llm_chain::{schema::Document, traits::VectorStore, vectorstores::qdrant::Qdrant};
+use llm_chain_openai::embeddings::Embeddings;
+use qdrant_client::{
+    prelude::{QdrantClient, QdrantClientConfig},
+    qdrant::{CreateCollection, Distance, VectorParams, VectorsConfig},
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // Qdrant prep
+    let config = QdrantClientConfig::from_url("http://localhost:6334");
+    let client = Arc::new(QdrantClient::new(Some(config)).await.unwrap());
+    let collection_name = "my-collection".to_string();
+    let embedding_size = 1536;
+
+    if !client
+        .has_collection(collection_name.clone())
+        .await
+        .unwrap()
+    {
+        client
+            .create_collection(&CreateCollection {
+                collection_name: collection_name.clone(),
+                vectors_config: Some(VectorsConfig {
+                    config: Some(qdrant_client::qdrant::vectors_config::Config::Params(
+                        VectorParams {
+                            size: embedding_size,
+                            distance: Distance::Cosine.into(),
+                            hnsw_config: None,
+                            quantization_config: None,
+                        },
+                    )),
+                }),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+    }
+    println!("OPENAI KEY: {}", std::env::var("OPENAI_API_KEY").unwrap());
+    let embeddings = llm_chain_openai::embeddings::Embeddings::default();
+
+    // Storing documents
+    let qdrant: Qdrant<Embeddings> = Qdrant::new(
+        client.clone(),
+        collection_name.clone(),
+        embeddings,
+        None,
+        None,
+    );
+
+    let doc_dog_definition = r#"The dog (Canis familiaris[4][5] or Canis lupus familiaris[5]) is a domesticated descendant of the wolf. Also called the domestic dog, it is derived from the extinct Pleistocene wolf,[6][7] and the modern wolf is the dog's nearest living relative.[8] Dogs were the first species to be domesticated[9][8] by hunter-gatherers over 15,000 years ago[7] before the development of agriculture.[1] Due to their long association with humans, dogs have expanded to a large number of domestic individuals[10] and gained the ability to thrive on a starch-rich diet that would be inadequate for other canids.[11]
+
+    The dog has been selectively bred over millennia for various behaviors, sensory capabilities, and physical attributes.[12] Dog breeds vary widely in shape, size, and color. They perform many roles for humans, such as hunting, herding, pulling loads, protection, assisting police and the military, companionship, therapy, and aiding disabled people. Over the millennia, dogs became uniquely adapted to human behavior, and the human–canine bond has been a topic of frequent study.[13] This influence on human society has given them the sobriquet of "man's best friend"."#.to_string();
+
+    let doc_woodstock_sound = r#"Sound for the concert was engineered by sound engineer Bill Hanley. "It worked very well", he says of the event. "I built special speaker columns on the hills and had 16 loudspeaker arrays in a square platform going up to the hill on 70-foot [21 m] towers. We set it up for 150,000 to 200,000 people. Of course, 500,000 showed up."[48] ALTEC designed marine plywood cabinets that weighed half a ton apiece and stood 6 feet (1.8 m) tall, almost 4 feet (1.2 m) deep, and 3 feet (0.91 m) wide. Each of these enclosures carried four 15-inch (380 mm) JBL D140 loudspeakers. The tweeters consisted of 4×2-Cell & 2×10-Cell Altec Horns. Behind the stage were three transformers providing 2,000 amperes of current to power the amplification setup.[49][page needed] For many years this system was collectively referred to as the Woodstock Bins.[50] The live performances were captured on two 8-track Scully recorders in a tractor trailer back stage by Edwin Kramer and Lee Osbourne on 1-inch Scotch recording tape at 15 ips, then mixed at the Record Plant studio in New York.[51]"#.to_string();
+
+    let doc_reddit_creep_shots = r#"A year after the closure of r/jailbait, another subreddit called r/CreepShots drew controversy in the press for hosting sexualized images of women without their knowledge.[34] In the wake of this media attention, u/violentacrez was added to r/CreepShots as a moderator;[35] reports emerged that Gawker reporter Adrian Chen was planning an exposé that would reveal the real-life identity of this user, who moderated dozens of controversial subreddits, as well as a few hundred general-interest communities. Several major subreddits banned links to Gawker in response to the impending exposé, and the account u/violentacrez was deleted.[36][37][38] Moderators defended their decisions to block the site from these sections of Reddit on the basis that the impending report was "doxing" (a term for exposing the identity of a pseudonymous person), and that such exposure threatened the site's structural integrity.[38]"#.to_string();
+
+    let doc_ids = qdrant
+        .add_documents(
+            vec![
+                doc_dog_definition,
+                doc_woodstock_sound,
+                doc_reddit_creep_shots,
+            ]
+            .into_iter()
+            .map(Document::new)
+            .collect(),
+        )
+        .await
+        .unwrap();
+
+    println!("Documents stored under IDs: {:?}", doc_ids);
+
+    let response = qdrant
+        .similarity_search(
+            "Sound engineering is involved with concerts and music events".to_string(),
+            1,
+        )
+        .await
+        .unwrap();
+
+    println!("Retrieved stored documents: {:?}", response);
+}

--- a/llm-chain-openai/src/embeddings.rs
+++ b/llm-chain-openai/src/embeddings.rs
@@ -15,7 +15,12 @@ pub struct Embeddings {
 
 #[derive(Debug, Error)]
 #[error(transparent)]
-pub struct OpenAIEmbeddingsError(#[from] OpenAIError);
+pub enum OpenAIEmbeddingsError {
+    #[error(transparent)]
+    Client(#[from] OpenAIError),
+    #[error("Request to OpenAI embeddings API was successful but response is empty")]
+    EmptyResponse,
+}
 
 impl EmbeddingsError for OpenAIEmbeddingsError {}
 
@@ -35,12 +40,27 @@ impl traits::Embeddings for Embeddings {
             .map(|r| r.data.into_iter().map(|e| e.embedding).collect())
             .map_err(|e| e.into())
     }
+
+    async fn embed_query(&self, query: String) -> Result<Vec<f32>, Self::Error> {
+        self.client
+            .embeddings()
+            .create(CreateEmbeddingRequest {
+                model: self.model.clone(),
+                user: None,
+                input: EmbeddingInput::from(query),
+            })
+            .await
+            .map(|r| r.data.into_iter())?
+            .map(|e| e.embedding)
+            .last()
+            .ok_or(OpenAIEmbeddingsError::EmptyResponse.into())
+    }
 }
 
 impl Default for Embeddings {
     fn default() -> Self {
         Self {
-            client: Default::default(),
+            client: async_openai::Client::default().into(),
             model: "text-embedding-ada-002".to_string(),
         }
     }

--- a/llm-chain/Cargo.toml
+++ b/llm-chain/Cargo.toml
@@ -31,6 +31,7 @@ markdown = { version = "1.0.0-alpha.7", optional = true }
 tera = { version = "1.18.1", optional = true }
 lazy_static = "1.4.0"
 uuid = { version = "1.3.1", features = ["v4"] }
+tonic = "0.9.1"
 
 [dev-dependencies]
 tokio = "1.27.0"

--- a/llm-chain/src/lib.rs
+++ b/llm-chain/src/lib.rs
@@ -24,6 +24,8 @@ pub mod serialization;
 mod templates;
 pub mod traits;
 
+pub mod schema;
+
 pub mod frame;
 
 pub mod tokens;

--- a/llm-chain/src/schema.rs
+++ b/llm-chain/src/schema.rs
@@ -1,6 +1,23 @@
-use std::collections::HashMap;
-
-pub struct Document {
+#[derive(Debug)]
+pub struct Document<M = EmptyMetadata> {
     pub page_content: String,
-    pub metadata: HashMap<String, String>,
+    pub metadata: Option<M>,
+}
+
+impl<M> Document<M> {
+    pub fn new(page_content: String) -> Self {
+        Document {
+            page_content,
+            metadata: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EmptyMetadata;
+
+impl From<()> for EmptyMetadata {
+    fn from(_: ()) -> Self {
+        EmptyMetadata
+    }
 }

--- a/llm-chain/src/schema.rs
+++ b/llm-chain/src/schema.rs
@@ -1,0 +1,6 @@
+use std::collections::HashMap;
+
+pub struct Document {
+    pub page_content: String,
+    pub metadata: HashMap<String, String>,
+}

--- a/llm-chain/src/traits.rs
+++ b/llm-chain/src/traits.rs
@@ -14,7 +14,7 @@ use std::{error::Error, fmt::Debug};
 use crate::{
     chains::sequential,
     output::Output,
-    schema::Document,
+    schema::{Document, EmptyMetadata},
     tokens::{PromptTokensError, TokenCount},
     Parameters,
 };
@@ -155,12 +155,16 @@ pub trait Embeddings {
 }
 
 #[async_trait]
-pub trait VectorStore<E: Embeddings> {
+pub trait VectorStore<E, M = EmptyMetadata>
+where
+    E: Embeddings,
+{
     type Error: Debug + Error + From<<E as Embeddings>::Error>;
     async fn add_texts(&self, texts: Vec<String>) -> Result<Vec<String>, Self::Error>;
+    async fn add_documents(&self, documents: Vec<Document<M>>) -> Result<Vec<String>, Self::Error>;
     async fn similarity_search(
         &self,
         query: String,
         limit: u32,
-    ) -> Result<Vec<Document>, Self::Error>;
+    ) -> Result<Vec<Document<M>>, Self::Error>;
 }

--- a/llm-chain/src/traits.rs
+++ b/llm-chain/src/traits.rs
@@ -14,6 +14,7 @@ use std::{error::Error, fmt::Debug};
 use crate::{
     chains::sequential,
     output::Output,
+    schema::Document,
     tokens::{PromptTokensError, TokenCount},
     Parameters,
 };
@@ -150,10 +151,16 @@ pub trait EmbeddingsError {}
 pub trait Embeddings {
     type Error: Debug + Error + EmbeddingsError;
     async fn embed_texts(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>, Self::Error>;
+    async fn embed_query(&self, query: String) -> Result<Vec<f32>, Self::Error>;
 }
 
 #[async_trait]
 pub trait VectorStore<E: Embeddings> {
     type Error: Debug + Error + From<<E as Embeddings>::Error>;
     async fn add_texts(&self, texts: Vec<String>) -> Result<Vec<String>, Self::Error>;
+    async fn similarity_search(
+        &self,
+        query: String,
+        limit: u32,
+    ) -> Result<Vec<Document>, Self::Error>;
 }

--- a/llm-chain/src/vectorstores/qdrant.rs
+++ b/llm-chain/src/vectorstores/qdrant.rs
@@ -189,7 +189,7 @@ where
             .map(|_| Uuid::new_v4().to_string())
             .collect::<Vec<String>>();
 
-        let points = ids
+        let points = embedding_vecs
             .clone()
             .into_iter()
             .zip(documents.into_iter())

--- a/llm-chain/src/vectorstores/qdrant.rs
+++ b/llm-chain/src/vectorstores/qdrant.rs
@@ -190,7 +190,6 @@ where
             .collect::<Vec<String>>();
 
         let points = embedding_vecs
-            .clone()
             .into_iter()
             .zip(documents.into_iter())
             .zip(ids.iter())


### PR DESCRIPTION
# Vector storage:
Add similarity_search to VectorStore trait

Add schema.rs with generic Document definition

Add EmptyMetadata as default metadata type for Document to make prototyping easier for library users

Implement similarity_search for Qdrant Vectorstore

Example of similarity_search for Qdrant Vectorstore

# Embeddings:
Add embed_query to Embeddings trait

Implement embed_query for OpenAI