### PR TITLE
Improvement: Error handling in tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "llm-chain",
  "qdrant-client",
  "serde",
+ "serde_yaml",
  "thiserror",
  "tiktoken-rs",
  "tokio",

--- a/llm-chain-openai/Cargo.toml
+++ b/llm-chain-openai/Cargo.toml
@@ -25,3 +25,5 @@ thiserror = "1.0.40"
 [dev-dependencies]
 tokio = "1.27.0"
 qdrant-client = "1.1.1"
+serde_yaml = { version = "0.9.21" }
+llm-chain = { path = "../llm-chain", version = "0.6.2" }

--- a/llm-chain-openai/examples/simple_invocation.rs
+++ b/llm-chain-openai/examples/simple_invocation.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tool_collection.add_tool(BashTool::new());
 
     let template = PromptTemplate::combine(vec![
-        tool_collection.to_prompt_template(),
+        tool_collection.to_prompt_template().unwrap(),
         PromptTemplate::tera("Please perform the following task: {{task}}."),
     ]);
 

--- a/llm-chain/examples/multitool.rs
+++ b/llm-chain/examples/multitool.rs
@@ -1,0 +1,70 @@
+use llm_chain::{
+    multitool,
+    tools::{
+        tools::{BashTool, BashToolError},
+        Format, Tool, ToolError,
+    },
+    tools::{ToolCollection, ToolDescription},
+};
+use thiserror::Error;
+
+/// Your custom tool's implementation:
+#[derive(Debug, Error)]
+#[error("MyTool custom error")]
+struct MyToolError(#[from] serde_yaml::Error);
+
+impl ToolError for MyToolError {}
+
+struct MyTool {}
+
+impl Tool for MyTool {
+    type Error = MyToolError;
+
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: "MyTool".into(),
+            description: "My custom implementation of a tool".into(),
+            description_context: "You are able to use my tool".into(),
+            input_format: Format::new(vec![]),
+            output_format: Format::new(vec![]),
+        }
+    }
+
+    fn invoke(&self, _: serde_yaml::Value) -> Result<serde_yaml::Value, Self::Error> {
+        Ok(serde_yaml::Value::Null)
+    }
+}
+
+// Final toolbox Tool type:
+multitool!(
+    Multitool,
+    MultitoolError,
+    BashTool,
+    BashToolError,
+    MyTool,
+    MyToolError
+);
+
+fn main() {
+    // Calling tool methods on the toolbox enum
+    let tool = BashTool {};
+    let my_tool = MyTool {};
+
+    println!("Original tool: {:?}", tool.description());
+    let toolbox1 = Multitool::BashTool(tool);
+    println!("Multitool description: {:?}", toolbox1.description());
+
+    println!("Original tool: {:?}", my_tool.description());
+    let toolbox2 = Multitool::MyTool(my_tool);
+    println!("Multitool description: {:?}", toolbox2.description());
+
+    // Adding tools (as multitools) to a ToolCollection
+    let tool = BashTool {};
+    let my_tool = MyTool {};
+
+    let mut collection = ToolCollection::<Multitool>::new();
+    collection.add_tool(tool.into());
+    collection.add_tool(my_tool.into());
+
+    println!("{}", collection.describe().unwrap());
+}

--- a/llm-chain/examples/tools_prompt.rs
+++ b/llm-chain/examples/tools_prompt.rs
@@ -9,7 +9,7 @@ fn main() {
 
     #[cfg(feature = "tera")]
     let prompt = PromptTemplate::combine(vec![
-        tool_collection.to_prompt_template(),
+        tool_collection.to_prompt_template().unwrap(),
         PromptTemplate::tera("Please perform the following task: {{text}}"),
     ]);
     #[cfg(not(feature = "tera"))]

--- a/llm-chain/src/tools/description.rs
+++ b/llm-chain/src/tools/description.rs
@@ -1,7 +1,7 @@
 use serde::{ser::SerializeMap, Serialize, Serializer};
 
 /// Represents a single parameter for a tool.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FormatPart {
     pub key: String,
     pub purpose: String,
@@ -24,6 +24,7 @@ impl<K: Into<String>, P: Into<String>> From<(K, P)> for FormatPart {
 }
 
 /// Represents the format for a tool's input or output.
+#[derive(Debug)]
 pub struct Format {
     pub parts: Vec<FormatPart>,
 }
@@ -61,7 +62,7 @@ pub trait Describe {
 }
 
 /// Represents the description of a tool, including its name, usage, and input/output formats.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct ToolDescription {
     pub name: String,
     pub description: String,

--- a/llm-chain/src/tools/mod.rs
+++ b/llm-chain/src/tools/mod.rs
@@ -21,7 +21,7 @@
 //!
 //! // Create a prompt indicating the LLM should use the provided tools.
 //! let prompt = PromptTemplate::static_string("Find information about Rust programming language.");
-//! let tool_prompt = PromptTemplate::combine(vec![tc.to_prompt_template(), prompt]);
+//! let tool_prompt = PromptTemplate::combine(vec![tc.to_prompt_template().unwrap(), prompt]);
 //! ```
 //!
 //! ## Modules
@@ -30,9 +30,12 @@
 
 mod collection;
 mod description;
+#[cfg(feature = "multitool_default")]
+pub mod multitool_default;
 pub use description::{Describe, Format, FormatPart, ToolDescription};
+pub mod multitool;
 mod tool;
 pub mod tools;
 
 pub use collection::{ToolCollection, ToolUseError};
-pub use tool::Tool;
+pub use tool::{Tool, ToolError};

--- a/llm-chain/src/tools/multitool.rs
+++ b/llm-chain/src/tools/multitool.rs
@@ -1,0 +1,58 @@
+#[macro_export]
+macro_rules! multitool {
+    ($multitool:ident, $error:ident, $($tool:ident, $tool_error:ident),+) => {
+        #[derive(Debug, Error)]
+        enum $error {
+            #[error(transparent)]
+            YamlError(#[from] serde_yaml::Error),
+            $(#[error(transparent)]
+            $tool_error(#[from] $tool_error)),+
+        }
+
+        impl ToolError for $error {}
+
+        enum $multitool {
+            $($tool($tool)),+
+        }
+
+        $(
+            impl From<$tool> for $multitool {
+                fn from(tool: $tool) -> Self {
+                    $multitool::$tool(tool)
+                }
+            }
+        )+
+
+        impl Tool for $multitool {
+            type Error = $error;
+
+            /// Returns the `ToolDescription` containing metadata about the tool.
+            fn description(&self) -> ToolDescription {
+                match self {
+                    $($multitool::$tool(t) => t.description()),+
+                }
+            }
+
+            /// Invokes the tool with the given YAML-formatted input.
+            ///
+            /// # Errors
+            ///
+            /// Returns an `ToolUseError` if the input is not in the expected format or if the tool
+            /// fails to produce a valid output.
+            fn invoke(&self, input: serde_yaml::Value) -> Result<serde_yaml::Value, Self::Error> {
+                match self {
+                    $($multitool::$tool(t) => t.invoke(input).map_err(|e| e.into())),+
+                }
+            }
+
+            /// Checks whether the tool matches the given name.
+            ///
+            /// This function is used to find the appropriate tool in a `ToolCollection` based on its name.
+            fn matches(&self, name: &str) -> bool {
+                match self {
+                    $($multitool::$tool(t) => t.description().name == name),+
+                }
+            }
+        }
+    };
+}

--- a/llm-chain/src/tools/multitool_default.rs
+++ b/llm-chain/src/tools/multitool_default.rs
@@ -1,11 +1,11 @@
-use crate::toolbox;
+use crate::multitool;
 use crate::tools::tools::{
     BashTool, BashToolError, ExitTool, ExitToolError, PythonTool, PythonToolError,
 };
 use crate::tools::{Tool, ToolDescription, ToolError};
 use thiserror::Error;
 
-toolbox!(
+multitool!(
     DefaultToolbox,
     DefaultToolboxError,
     BashTool,

--- a/llm-chain/src/tools/multitool_default.rs
+++ b/llm-chain/src/tools/multitool_default.rs
@@ -1,0 +1,17 @@
+use crate::toolbox;
+use crate::tools::tools::{
+    BashTool, BashToolError, ExitTool, ExitToolError, PythonTool, PythonToolError,
+};
+use crate::tools::{Tool, ToolDescription, ToolError};
+use thiserror::Error;
+
+toolbox!(
+    DefaultToolbox,
+    DefaultToolboxError,
+    BashTool,
+    BashToolError,
+    ExitTool,
+    ExitToolError,
+    PythonTool,
+    PythonToolError
+);

--- a/llm-chain/src/tools/tool.rs
+++ b/llm-chain/src/tools/tool.rs
@@ -12,7 +12,7 @@ macro_rules! gen_invoke_function {
 }
 pub(crate) use gen_invoke_function;
 
-/// Marker trait is required so we do not use ToolUseError in our trait; this will allow users to easily define their own tools with their own errors
+/// Marker trait for Tool errors. It is needed so the concrete Errors can have a derived From<ToolError>
 pub trait ToolError {}
 
 /// The `Tool` trait defines an interface for tools that can be added to a `ToolCollection`.

--- a/llm-chain/src/tools/tool.rs
+++ b/llm-chain/src/tools/tool.rs
@@ -1,13 +1,10 @@
-use super::collection::ToolUseError;
 use super::description::ToolDescription;
 
 macro_rules! gen_invoke_function {
     () => {
-        fn invoke(
-            &self,
-            input: serde_yaml::Value,
-        ) -> Result<serde_yaml::Value, crate::tools::collection::ToolUseError> {
-            let input = serde_yaml::from_value(input)?;
+        fn invoke(&self, input: serde_yaml::Value) -> Result<serde_yaml::Value, Self::Error> {
+            let input = serde_yaml::from_value(input)
+                .map_err(|e| <serde_yaml::Error as Into<Self::Error>>::into(e))?;
             let output = self.invoke_typed(&input)?;
             Ok(serde_yaml::to_value(output)?)
         }
@@ -15,11 +12,16 @@ macro_rules! gen_invoke_function {
 }
 pub(crate) use gen_invoke_function;
 
+/// Marker trait is required so we do not use ToolUseError in our trait; this will allow users to easily define their own tools with their own errors
+pub trait ToolError {}
+
 /// The `Tool` trait defines an interface for tools that can be added to a `ToolCollection`.
 ///
 /// A `Tool` is a function that takes a YAML-formatted input and returns a YAML-formatted output.
 /// It has a description that contains metadata about the tool, such as its name and usage.
 pub trait Tool {
+    type Error: std::fmt::Debug + std::error::Error + ToolError + From<serde_yaml::Error>;
+
     /// Returns the `ToolDescription` containing metadata about the tool.
     fn description(&self) -> ToolDescription;
 
@@ -29,7 +31,7 @@ pub trait Tool {
     ///
     /// Returns an `ToolUseError` if the input is not in the expected format or if the tool
     /// fails to produce a valid output.
-    fn invoke(&self, input: serde_yaml::Value) -> Result<serde_yaml::Value, ToolUseError>;
+    fn invoke(&self, input: serde_yaml::Value) -> Result<serde_yaml::Value, Self::Error>;
 
     /// Checks whether the tool matches the given name.
     ///

--- a/llm-chain/src/tools/tools/exit.rs
+++ b/llm-chain/src/tools/tools/exit.rs
@@ -1,7 +1,7 @@
-use crate::tools::collection::ToolUseError;
 use crate::tools::description::{Describe, Format, ToolDescription};
-use crate::tools::tool::{gen_invoke_function, Tool};
+use crate::tools::tool::{gen_invoke_function, Tool, ToolError};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// A tool that exits the program with the given status code.
 pub struct ExitTool {}
@@ -41,14 +41,25 @@ impl Describe for ExitToolOutput {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum ExitToolError {
+    #[error(transparent)]
+    YamlError(#[from] serde_yaml::Error),
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+}
+
+impl ToolError for ExitToolError {}
+
 impl ExitTool {
     /// Invokes the `ExitTool` with the provided input.
-    fn invoke_typed(&self, input: &ExitToolInput) -> Result<ExitToolOutput, ToolUseError> {
+    fn invoke_typed(&self, input: &ExitToolInput) -> Result<ExitToolOutput, ExitToolError> {
         std::process::exit(input.status_code);
     }
 }
 
 impl Tool for ExitTool {
+    type Error = ExitToolError;
     gen_invoke_function!();
 
     /// Returns a `ToolDescription` for `ExitTool`.

--- a/llm-chain/src/tools/tools/mod.rs
+++ b/llm-chain/src/tools/tools/mod.rs
@@ -4,6 +4,6 @@
 mod bash;
 mod exit;
 mod python;
-pub use bash::BashTool;
-pub use exit::ExitTool;
-pub use python::PythonTool;
+pub use bash::{BashTool, BashToolError};
+pub use exit::{ExitTool, ExitToolError};
+pub use python::{PythonTool, PythonToolError};


### PR DESCRIPTION
- add multitool macro for combining Tools into a Tool enum

- use multitolol macro as a way of building type-safe ToolCollections with library- and user- defined Tools 

- add a default multitool that combines all library-defined tools; configure it as an optional feature

- remove unwrap() calls in tools, use Results where necessary

Before writing multitool!, I considered using https://docs.rs/enum_dispatch/latest/enum_dispatch/

Unfortunately, it cannot and will not handle associated types (it's mentioned in one of the issues in the project repo), as it's much too complex of a feature to do in a generic way, but not that hard to do for our specific case