### PR TITLE
Feature: Vectorstore tool

### DIFF
--- a/llm-chain-openai/Cargo.toml
+++ b/llm-chain-openai/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = "1.0.40"
 tokio = "1.27.0"
 qdrant-client = "1.1.1"
 serde_yaml = { version = "0.9.21" }
-llm-chain = { path = "../llm-chain", version = "0.6.2" }
+llm-chain = { path = "../llm-chain" }

--- a/llm-chain-openai/examples/qdrant_vectorstore.rs
+++ b/llm-chain-openai/examples/qdrant_vectorstore.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use llm_chain::{traits::VectorStore, vectorstores::qdrant::Qdrant};
+use llm_chain::{schema::EmptyMetadata, traits::VectorStore, vectorstores::qdrant::Qdrant};
 use qdrant_client::{
     prelude::{QdrantClient, QdrantClientConfig},
     qdrant::{CreateCollection, Distance, VectorParams, VectorsConfig},
@@ -41,7 +41,7 @@ async fn main() {
     let embeddings = llm_chain_openai::embeddings::Embeddings::default();
 
     // Storing documents
-    let qdrant: Qdrant<llm_chain_openai::embeddings::Embeddings> = Qdrant::new(
+    let qdrant: Qdrant<llm_chain_openai::embeddings::Embeddings, EmptyMetadata> = Qdrant::new(
         client.clone(),
         collection_name.clone(),
         embeddings,

--- a/llm-chain-openai/examples/similarity_search.rs
+++ b/llm-chain-openai/examples/similarity_search.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use llm_chain::{schema::Document, traits::VectorStore, vectorstores::qdrant::Qdrant};
+use llm_chain::{
+    schema::{Document, EmptyMetadata},
+    traits::VectorStore,
+    vectorstores::qdrant::Qdrant,
+};
 use llm_chain_openai::embeddings::Embeddings;
 use qdrant_client::{
     prelude::{QdrantClient, QdrantClientConfig},
@@ -42,7 +46,7 @@ async fn main() {
     let embeddings = llm_chain_openai::embeddings::Embeddings::default();
 
     // Storing documents
-    let qdrant: Qdrant<Embeddings> = Qdrant::new(
+    let qdrant: Qdrant<Embeddings, EmptyMetadata> = Qdrant::new(
         client.clone(),
         collection_name.clone(),
         embeddings,

--- a/llm-chain-openai/examples/simple_agent.rs
+++ b/llm-chain-openai/examples/simple_agent.rs
@@ -1,23 +1,17 @@
 use llm_chain::executor;
-use llm_chain::multitool;
 
 use async_trait::async_trait;
 use llm_chain::output::Output;
 use llm_chain::parameters;
 use llm_chain::prompt::chat::{ChatMessage, ChatPrompt, ChatRole};
-use llm_chain::step::Step;
-use llm_chain::tools::tools::{BashTool, BashToolError, ExitTool, ExitToolError};
 use llm_chain::tools::ToolCollection;
 use llm_chain::tools::{Tool, ToolDescription, ToolError};
 use llm_chain::traits::Executor as ExecutorTrait;
-use llm_chain::Parameters;
-use llm_chain::PromptTemplate;
 
 use llm_chain::tools::tools::{
     BashTool, BashToolError, BashToolInput, BashToolOutput, ExitTool, ExitToolError, ExitToolInput,
     ExitToolOutput,
 };
-use llm_chain::tools::{Tool, ToolCollection, ToolDescription, ToolError};
 use llm_chain::{multitool, PromptTemplate};
 use llm_chain::{traits::StepExt, Parameters};
 use llm_chain_openai::chatgpt::{Executor, Step};

--- a/llm-chain-openai/examples/simple_agent.rs
+++ b/llm-chain-openai/examples/simple_agent.rs
@@ -1,5 +1,7 @@
 use llm_chain::executor;
 use llm_chain::multitool;
+
+use async_trait::async_trait;
 use llm_chain::output::Output;
 use llm_chain::parameters;
 use llm_chain::prompt::chat::{ChatMessage, ChatPrompt, ChatRole};
@@ -10,15 +12,31 @@ use llm_chain::tools::{Tool, ToolDescription, ToolError};
 use llm_chain::traits::Executor as ExecutorTrait;
 use llm_chain::Parameters;
 use llm_chain::PromptTemplate;
+
+use llm_chain::tools::tools::{
+    BashTool, BashToolError, BashToolInput, BashToolOutput, ExitTool, ExitToolError, ExitToolInput,
+    ExitToolOutput,
+};
+use llm_chain::tools::{Tool, ToolCollection, ToolDescription, ToolError};
+use llm_chain::{multitool, PromptTemplate};
+use llm_chain::{traits::StepExt, Parameters};
+use llm_chain_openai::chatgpt::{Executor, Step};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 // A simple example generating a prompt with some tools.
 multitool!(
     MyMultitool,
+    MyMultiToolInput,
+    MyMultiToolOutput,
     MyMultitoolError,
     BashTool,
+    BashToolInput,
+    BashToolOutput,
     BashToolError,
     ExitTool,
+    ExitToolInput,
+    ExitToolOutput,
     ExitToolError
 );
 
@@ -48,7 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let message_text = res.primary_textual_output().await.unwrap();
         println!("Assistant: {}", message_text);
         println!("=============");
-        let next_step = match tool_collection.process_chat_input(&message_text) {
+        let next_step = match tool_collection.process_chat_input(&message_text).await {
             Ok(x) => PromptTemplate::static_string(format!(
                 "```yaml
                     {}

--- a/llm-chain-openai/examples/simple_invocation.rs
+++ b/llm-chain-openai/examples/simple_invocation.rs
@@ -33,7 +33,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     println!("{}", result);
-    match tool_collection.process_chat_input(&result.primary_textual_output().await.unwrap()) {
+    match tool_collection
+        .process_chat_input(&result.primary_textual_output().await.unwrap())
+        .await
+    {
         Ok(output) => println!("{}", output),
         Err(e) => println!("Error: {}", e),
     }

--- a/llm-chain-openai/examples/simple_invocation.rs
+++ b/llm-chain-openai/examples/simple_invocation.rs
@@ -29,14 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap();
 
     let result = Step::for_prompt(prompt.into())
-        .run(
-            &{
-                let mut params = llm_chain::Parameters::new();
-                params = params.with("task", task);
-                params
-            },
-            &exec,
-        )
+        .run(&parameters!("task" => task), &exec)
         .await?;
 
     println!("{}", result);

--- a/llm-chain-openai/examples/simple_invocation.rs
+++ b/llm-chain-openai/examples/simple_invocation.rs
@@ -29,7 +29,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap();
 
     let result = Step::for_prompt(prompt.into())
-        .run(&parameters!("task" => task), &exec)
+        .run(
+            &{
+                let mut params = llm_chain::Parameters::new();
+                params = params.with("task", task);
+                params
+            },
+            &exec,
+        )
         .await?;
 
     println!("{}", result);

--- a/llm-chain-openai/examples/vectorstore_tool_invocation.rs
+++ b/llm-chain-openai/examples/vectorstore_tool_invocation.rs
@@ -128,7 +128,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //
     // This is a situation that you may encounter with other tools from our library, as well as your own.
     //
-    // If it so happens that the model defers to a more general tool, it most likely means that your prompt
+    // If it so happens that the model defers to a more general tool, it most likely means that the tool's prompt
     // is not aligned with what you want the model to do.
     //
     // Note that it does not necessarily mean that you did not describe your tool well -

--- a/llm-chain-openai/examples/vectorstore_tool_invocation.rs
+++ b/llm-chain-openai/examples/vectorstore_tool_invocation.rs
@@ -1,0 +1,302 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use llm_chain::output::Output;
+use llm_chain::prompt::chat::{ChatMessage, ChatPrompt, ChatRole};
+use llm_chain::schema::Document;
+use llm_chain::tools::tools::{BashTool, VectorStoreTool};
+use llm_chain::tools::{Format, Tool, ToolCollection, ToolDescription, ToolError};
+use llm_chain::vectorstores::qdrant::Qdrant;
+use llm_chain::{multitool, PromptTemplate};
+use llm_chain::{traits::StepExt, Parameters};
+use llm_chain_openai::chatgpt::{Executor, Step};
+use llm_chain_openai::embeddings::Embeddings;
+use qdrant_client::prelude::{QdrantClient, QdrantClientConfig};
+use qdrant_client::qdrant::{CreateCollection, Distance, VectorParams, VectorsConfig};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+// A simple example generating a prompt with some tools.
+
+/// Your custom tool's implementation:
+#[derive(Debug, Error)]
+#[error("MyTool custom error")]
+struct MyToolError(#[from] serde_yaml::Error);
+
+impl ToolError for MyToolError {}
+
+#[derive(Serialize, Deserialize)]
+struct MyToolInput;
+#[derive(Serialize, Deserialize)]
+struct MyToolOutput;
+
+struct MyTool {}
+
+#[async_trait]
+impl Tool for MyTool {
+    type Input = MyToolInput;
+    type Output = MyToolOutput;
+    type Error = MyToolError;
+
+    fn description(&self) -> ToolDescription {
+        ToolDescription {
+            name: "MyTool".into(),
+            description: "My custom implementation of a tool".into(),
+            description_context: "You are able to use my tool".into(),
+            input_format: Format::new(vec![]),
+            output_format: Format::new(vec![]),
+        }
+    }
+
+    async fn invoke(&self, _: serde_yaml::Value) -> Result<serde_yaml::Value, Self::Error> {
+        Ok(serde_yaml::Value::Null)
+    }
+
+    async fn invoke_typed(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
+        todo!()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct MyMetadata;
+
+// `multitool!` macro cannot handle generic annotations as of now; for now you will need to pass concrete arguments and alias your types
+type QdrantTool = VectorStoreTool<Embeddings, Qdrant<Embeddings, MyMetadata>>;
+type QdrantToolInput = <QdrantTool as Tool>::Input;
+type QdrantToolOutput = <QdrantTool as Tool>::Output;
+type QdrantToolError = <QdrantTool as Tool>::Error;
+
+#[derive(Serialize, Deserialize)]
+enum MultiToolInput {
+    QdrantToolInput(QdrantToolInput),
+    MyToolInput(MyToolInput),
+}
+impl TryInto<QdrantToolInput> for MultiToolInput {
+    type Error = MultitoolError;
+    fn try_into(self) -> Result<QdrantToolInput, Self::Error> {
+        if let MultiToolInput::QdrantToolInput(t) = self {
+            Ok(t)
+        } else {
+            Err(MultitoolError::BadVariant)
+        }
+    }
+}
+impl TryInto<MyToolInput> for MultiToolInput {
+    type Error = MultitoolError;
+    fn try_into(self) -> Result<MyToolInput, Self::Error> {
+        if let MultiToolInput::MyToolInput(t) = self {
+            Ok(t)
+        } else {
+            Err(MultitoolError::BadVariant)
+        }
+    }
+}
+#[derive(Serialize, Deserialize)]
+enum MultiToolOutput {
+    QdrantToolOutput(QdrantToolOutput),
+    MyToolOutput(MyToolOutput),
+}
+impl From<QdrantToolOutput> for MultiToolOutput {
+    fn from(tool: QdrantToolOutput) -> Self {
+        MultiToolOutput::QdrantToolOutput(tool)
+    }
+}
+impl From<MyToolOutput> for MultiToolOutput {
+    fn from(tool: MyToolOutput) -> Self {
+        MultiToolOutput::MyToolOutput(tool)
+    }
+}
+impl TryInto<QdrantToolOutput> for MultiToolOutput {
+    type Error = MultitoolError;
+    fn try_into(self) -> Result<QdrantToolOutput, Self::Error> {
+        if let MultiToolOutput::QdrantToolOutput(t) = self {
+            Ok(t)
+        } else {
+            Err(MultitoolError::BadVariant)
+        }
+    }
+}
+impl TryInto<MyToolOutput> for MultiToolOutput {
+    type Error = MultitoolError;
+    fn try_into(self) -> Result<MyToolOutput, Self::Error> {
+        if let MultiToolOutput::MyToolOutput(t) = self {
+            Ok(t)
+        } else {
+            Err(MultitoolError::BadVariant)
+        }
+    }
+}
+#[derive(Debug, Error)]
+enum MultitoolError {
+    #[error("Could not convert")]
+    BadVariant,
+    #[error(transparent)]
+    YamlError(#[from] serde_yaml::Error),
+    #[error(transparent)]
+    QdrantToolError(#[from] QdrantToolError),
+    #[error(transparent)]
+    MyToolError(#[from] MyToolError),
+}
+impl ToolError for MultitoolError {}
+
+enum Multitool {
+    QdrantTool(QdrantTool),
+    MyTool(MyTool),
+}
+impl From<QdrantTool> for Multitool {
+    fn from(tool: QdrantTool) -> Self {
+        Multitool::QdrantTool(tool)
+    }
+}
+impl From<MyTool> for Multitool {
+    fn from(tool: MyTool) -> Self {
+        Multitool::MyTool(tool)
+    }
+}
+#[async_trait]
+impl Tool for Multitool {
+    type Input = MultiToolInput;
+    type Output = MultiToolOutput;
+    type Error = MultitoolError;
+    async fn invoke_typed(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
+        match (self, input) {
+            (Multitool::QdrantTool(t), MultiToolInput::QdrantToolInput(i)) => t
+                .invoke_typed(i)
+                .await
+                .map(|o| <QdrantToolOutput as Into<Self::Output>>::into(o))
+                .map_err(|e| e.into()),
+            (Multitool::MyTool(t), MultiToolInput::MyToolInput(i)) => t
+                .invoke_typed(i)
+                .await
+                .map(|o| <MyToolOutput as Into<Self::Output>>::into(o))
+                .map_err(|e| e.into()),
+            _ => Err(MultitoolError::BadVariant),
+        }
+    }
+    #[doc = " Returns the `ToolDescription` containing metadata about the tool."]
+    fn description(&self) -> ToolDescription {
+        match self {
+            Multitool::QdrantTool(t) => t.description(),
+            Multitool::MyTool(t) => t.description(),
+        }
+    }
+    #[doc = " Invokes the tool with the given YAML-formatted input."]
+    #[doc = ""]
+    #[doc = " # Errors"]
+    #[doc = ""]
+    #[doc = " Returns an `ToolUseError` if the input is not in the expected format or if the tool"]
+    #[doc = " fails to produce a valid output."]
+    async fn invoke(&self, input: serde_yaml::Value) -> Result<serde_yaml::Value, Self::Error> {
+        match self {
+            Multitool::QdrantTool(t) => t.invoke(input).await.map_err(|e| e.into()),
+            Multitool::MyTool(t) => t.invoke(input).await.map_err(|e| e.into()),
+        }
+    }
+    #[doc = " Checks whether the tool matches the given name."]
+    #[doc = ""]
+    #[doc = " This function is used to find the appropriate tool in a `ToolCollection` based on its name."]
+    fn matches(&self, name: &str) -> bool {
+        match self {
+            Multitool::QdrantTool(t) => t.description().name == name,
+            Multitool::MyTool(t) => t.description().name == name,
+        }
+    }
+}
+
+async fn build_local_qdrant() -> Qdrant<Embeddings> {
+    // Qdrant prep
+    let config = QdrantClientConfig::from_url("http://localhost:6334");
+    let client = Arc::new(QdrantClient::new(Some(config)).await.unwrap());
+    let collection_name = "my-collection".to_string();
+    let embedding_size = 1536;
+
+    if !client
+        .has_collection(collection_name.clone())
+        .await
+        .unwrap()
+    {
+        client
+            .create_collection(&CreateCollection {
+                collection_name: collection_name.clone(),
+                vectors_config: Some(VectorsConfig {
+                    config: Some(qdrant_client::qdrant::vectors_config::Config::Params(
+                        VectorParams {
+                            size: embedding_size,
+                            distance: Distance::Cosine.into(),
+                            hnsw_config: None,
+                            quantization_config: None,
+                        },
+                    )),
+                }),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+    }
+
+    let embeddings = llm_chain_openai::embeddings::Embeddings::default();
+
+    let qdrant = Qdrant::new(client, collection_name, embeddings, None, None);
+
+    let doc_dog_definition = r#"The dog (Canis familiaris[4][5] or Canis lupus familiaris[5]) is a domesticated descendant of the wolf. Also called the domestic dog, it is derived from the extinct Pleistocene wolf,[6][7] and the modern wolf is the dog's nearest living relative.[8] Dogs were the first species to be domesticated[9][8] by hunter-gatherers over 15,000 years ago[7] before the development of agriculture.[1] Due to their long association with humans, dogs have expanded to a large number of domestic individuals[10] and gained the ability to thrive on a starch-rich diet that would be inadequate for other canids.[11]
+    
+        The dog has been selectively bred over millennia for various behaviors, sensory capabilities, and physical attributes.[12] Dog breeds vary widely in shape, size, and color. They perform many roles for humans, such as hunting, herding, pulling loads, protection, assisting police and the military, companionship, therapy, and aiding disabled people. Over the millennia, dogs became uniquely adapted to human behavior, and the human–canine bond has been a topic of frequent study.[13] This influence on human society has given them the sobriquet of "man's best friend"."#.to_string();
+
+    let doc_woodstock_sound = r#"Sound for the concert was engineered by sound engineer Bill Hanley. "It worked very well", he says of the event. "I built special speaker columns on the hills and had 16 loudspeaker arrays in a square platform going up to the hill on 70-foot [21 m] towers. We set it up for 150,000 to 200,000 people. Of course, 500,000 showed up."[48] ALTEC designed marine plywood cabinets that weighed half a ton apiece and stood 6 feet (1.8 m) tall, almost 4 feet (1.2 m) deep, and 3 feet (0.91 m) wide. Each of these enclosures carried four 15-inch (380 mm) JBL D140 loudspeakers. The tweeters consisted of 4×2-Cell & 2×10-Cell Altec Horns. Behind the stage were three transformers providing 2,000 amperes of current to power the amplification setup.[49][page needed] For many years this system was collectively referred to as the Woodstock Bins.[50] The live performances were captured on two 8-track Scully recorders in a tractor trailer back stage by Edwin Kramer and Lee Osbourne on 1-inch Scotch recording tape at 15 ips, then mixed at the Record Plant studio in New York.[51]"#.to_string();
+
+    let doc_reddit_creep_shots = r#"A year after the closure of r/jailbait, another subreddit called r/CreepShots drew controversy in the press for hosting sexualized images of women without their knowledge.[34] In the wake of this media attention, u/violentacrez was added to r/CreepShots as a moderator;[35] reports emerged that Gawker reporter Adrian Chen was planning an exposé that would reveal the real-life identity of this user, who moderated dozens of controversial subreddits, as well as a few hundred general-interest communities. Several major subreddits banned links to Gawker in response to the impending exposé, and the account u/violentacrez was deleted.[36][37][38] Moderators defended their decisions to block the site from these sections of Reddit on the basis that the impending report was "doxing" (a term for exposing the identity of a pseudonymous person), and that such exposure threatened the site's structural integrity.[38]"#.to_string();
+
+    let doc_ids = qdrant
+        .add_documents(
+            vec![
+                doc_dog_definition,
+                doc_woodstock_sound,
+                doc_reddit_creep_shots,
+            ]
+            .into_iter()
+            .map(Document::new)
+            .collect(),
+        )
+        .await
+        .unwrap();
+
+    println!("Documents stored under IDs: {:?}", doc_ids);
+    qdrant
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    std::env::var("OPENAI_API_KEY").expect(
+        "You need an OPENAI_API_KEY env var with a valid OpenAI API key to run this example",
+    );
+    let qdrant = build_local_qdrant().await;
+
+    let exec = Executor::new_default();
+
+    let mut tool_collection = ToolCollection::<Multitool>::new();
+    tool_collection.add_tool(BashTool::new().into());
+    tool_collection.add_tool(QdrantTool::new(qdrant, "random facts", "all sorts of facts").into());
+
+    let template = PromptTemplate::combine(vec![
+        tool_collection.to_prompt_template().unwrap(),
+        PromptTemplate::tera("Please perform the following task: {{task}}."),
+    ]);
+
+    let task = "Tell me something about dogs";
+
+    let prompt = ChatPrompt::builder()
+        .system("You are an automated agent for performing tasks. Your output must always be YAML.")
+        .add_message(ChatMessage::from_template(ChatRole::User, template))
+        .build()
+        .unwrap();
+
+    let result = Step::for_prompt(prompt)
+        .run(&Parameters::new().with("task", task), &exec)
+        .await?;
+
+    println!("{}", result);
+    match tool_collection.process_chat_input(&result.primary_textual_output().await.unwrap()) {
+        Ok(output) => println!("{}", output),
+        Err(e) => println!("Error: {}", e),
+    }
+    Ok(())
+}

--- a/llm-chain-openai/examples/vectorstore_tool_invocation.rs
+++ b/llm-chain-openai/examples/vectorstore_tool_invocation.rs
@@ -1,3 +1,4 @@
+use llm_chain::executor;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -11,7 +12,7 @@ use llm_chain::tools::tools::{BashToolError, BashToolInput, BashToolOutput};
 use llm_chain::tools::{Tool, ToolCollection, ToolDescription, ToolError};
 use llm_chain::traits::VectorStore;
 use llm_chain::vectorstores::qdrant::{Qdrant, QdrantError};
-use llm_chain::{multitool, PromptTemplate};
+use llm_chain::{multitool, parameters, PromptTemplate};
 use llm_chain::{traits::StepExt, Parameters};
 use llm_chain_openai::chatgpt::{Executor, Step};
 use llm_chain_openai::embeddings::{Embeddings, OpenAIEmbeddingsError};
@@ -117,7 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let qdrant = build_local_qdrant().await;
 
-    let exec = Executor::new_default();
+    let exec = executor!().unwrap();
 
     let mut tool_collection = ToolCollection::<Multitool>::new();
 
@@ -151,7 +152,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let template = PromptTemplate::combine(vec![
         tool_collection.to_prompt_template().unwrap(),
-        PromptTemplate::tera("Please perform the following task: {{task}}."),
+        PromptTemplate::legacy("Please perform the following task: {{task}}."),
     ]);
 
     let task = "Tell me something about dogs";
@@ -162,9 +163,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()
         .unwrap();
 
-    let result = Step::for_prompt(prompt)
-        .run(&Parameters::new().with("task", task), &exec)
-        .await?;
+    let result = Step::for_prompt(prompt.into())
+        .run(&parameters!("task" => task), &exec)
+        .await
+        .unwrap();
 
     println!("{}", result);
     match tool_collection

--- a/llm-chain-openai/src/chatgpt/prompt.rs
+++ b/llm-chain-openai/src/chatgpt/prompt.rs
@@ -18,9 +18,10 @@ fn convert_role(role: chat::ChatRole) -> Role {
 
 fn format_chat_message(
     message: chat::ChatMessage,
+    parameters: &Parameters,
 ) -> Result<ChatCompletionRequestMessage, PromptTemplateError> {
     let role = convert_role(message.role());
-    let content = message.content().format(&Parameters::new())?;
+    let content = message.content().format(parameters)?;
     Ok(ChatCompletionRequestMessage {
         role,
         content,
@@ -30,16 +31,20 @@ fn format_chat_message(
 
 fn format_chat_messages(
     messages: Vec<chat::ChatMessage>,
+    parameters: &Parameters,
 ) -> Result<Vec<ChatCompletionRequestMessage>, PromptTemplateError> {
-    messages.into_iter().map(format_chat_message).collect()
+    messages
+        .into_iter()
+        .map(|m| format_chat_message(m, parameters))
+        .collect()
 }
 
 pub fn create_chat_completion_request(
     model: &Model,
     prompt: &Prompt,
-    _parameters: &Parameters,
+    parameters: &Parameters,
 ) -> Result<CreateChatCompletionRequest, PromptTemplateError> {
-    let messages = format_chat_messages(prompt.as_chat_prompt())?;
+    let messages = format_chat_messages(prompt.as_chat_prompt(), parameters)?;
     Ok(CreateChatCompletionRequest {
         model: model.to_string(),
         messages,

--- a/llm-chain/examples/multitool.rs
+++ b/llm-chain/examples/multitool.rs
@@ -1,11 +1,13 @@
+use async_trait::async_trait;
 use llm_chain::{
     multitool,
     tools::{
-        tools::{BashTool, BashToolError},
+        tools::{BashTool, BashToolError, BashToolInput, BashToolOutput},
         Format, Tool, ToolError,
     },
     tools::{ToolCollection, ToolDescription},
 };
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Your custom tool's implementation:
@@ -15,9 +17,17 @@ struct MyToolError(#[from] serde_yaml::Error);
 
 impl ToolError for MyToolError {}
 
+#[derive(Serialize, Deserialize)]
+struct MyToolInput(());
+#[derive(Serialize, Deserialize)]
+struct MyToolOutput(());
+
 struct MyTool {}
 
+#[async_trait]
 impl Tool for MyTool {
+    type Input = MyToolInput;
+    type Output = MyToolOutput;
     type Error = MyToolError;
 
     fn description(&self) -> ToolDescription {
@@ -30,18 +40,28 @@ impl Tool for MyTool {
         }
     }
 
-    fn invoke(&self, _: serde_yaml::Value) -> Result<serde_yaml::Value, Self::Error> {
-        Ok(serde_yaml::Value::Null)
+    async fn invoke(&self, _: serde_yaml::Value) -> Result<serde_yaml::Value, Self::Error> {
+        todo!()
+    }
+
+    async fn invoke_typed(&self, _: &Self::Input) -> Result<Self::Output, Self::Error> {
+        todo!()
     }
 }
 
 // Final toolbox Tool type:
 multitool!(
     Multitool,
+    MultiToolInput,
+    MultiToolOutput,
     MultitoolError,
     BashTool,
+    BashToolInput,
+    BashToolOutput,
     BashToolError,
     MyTool,
+    MyToolInput,
+    MyToolOutput,
     MyToolError
 );
 

--- a/llm-chain/src/parameters.rs
+++ b/llm-chain/src/parameters.rs
@@ -200,11 +200,11 @@ macro_rules! parameters {
     ($text:expr) => {
         llm_chain::Parameters::new_with_text($text)
     };
-    ($($key:expr => $value:expr),* $(,)?) => {{
+    ($($key:expr => $value:expr),+$(,)?) => {{
         let mut params = llm_chain::Parameters::new();
         $(
             params = params.with($key, $value);
-        )*
+        )+
         params
     }};
 }

--- a/llm-chain/src/tools/collection.rs
+++ b/llm-chain/src/tools/collection.rs
@@ -26,7 +26,7 @@ pub enum ToolUseError<E: ToolError> {
 
 impl<T> ToolCollection<T>
 where
-    T: Tool,
+    T: Tool + Send + Sync,
 {
     pub fn new() -> Self {
         Self { tools: vec![] }
@@ -36,7 +36,7 @@ where
         self.tools.push(tool);
     }
 
-    pub fn invoke(
+    pub async fn invoke(
         &self,
         name: &str,
         input: &serde_yaml::Value,
@@ -46,7 +46,7 @@ where
             .iter()
             .find(|t| t.matches(name))
             .ok_or(ToolUseError::ToolNotFound)?;
-        tool.invoke(input.clone()).map_err(|e| e.into())
+        tool.invoke(input.clone()).await.map_err(|e| e.into())
     }
 
     /// Process chat input and execute the appropriate tool.
@@ -58,7 +58,7 @@ where
     ///
     /// Returns an `OpaqueError` variant if the input is not a valid YAML or
     /// if the specified tool is not found.
-    pub fn process_chat_input(
+    pub async fn process_chat_input(
         &self,
         data: &str,
     ) -> Result<String, ToolUseError<<T as Tool>::Error>> {
@@ -66,7 +66,9 @@ where
         if tool_invocations.len() != 1 {
             return Err(ToolUseError::InvalidInvocation);
         }
-        let output = self.invoke(&tool_invocations[0].command, &tool_invocations[0].input)?;
+        let output = self
+            .invoke(&tool_invocations[0].command, &tool_invocations[0].input)
+            .await?;
         Ok(serde_yaml::to_string(&output)?)
     }
 

--- a/llm-chain/src/tools/collection.rs
+++ b/llm-chain/src/tools/collection.rs
@@ -69,7 +69,7 @@ where
         let output = self
             .invoke(&tool_invocations[0].command, &tool_invocations[0].input)
             .await?;
-        Ok(serde_yaml::to_string(&output)?)
+        serde_yaml::to_string(&output).map_err(|e| e.into())
     }
 
     /// Generate a YAML-formatted string describing the available tools.

--- a/llm-chain/src/tools/multitool_default.rs
+++ b/llm-chain/src/tools/multitool_default.rs
@@ -1,17 +1,28 @@
 use crate::multitool;
 use crate::tools::tools::{
-    BashTool, BashToolError, ExitTool, ExitToolError, PythonTool, PythonToolError,
+    BashTool, BashToolError, BashToolInput, BashToolOutput, ExitTool, ExitToolError, ExitToolInput,
+    ExitToolOutput, PythonTool, PythonToolError, PythonToolInput, PythonToolOutput,
 };
 use crate::tools::{Tool, ToolDescription, ToolError};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 multitool!(
     DefaultToolbox,
+    DefaultToolboxInput,
+    DefaultToolboxOutput,
     DefaultToolboxError,
     BashTool,
+    BashToolInput,
+    BashToolOutput,
     BashToolError,
     ExitTool,
+    ExitToolInput,
+    ExitToolOutput,
     ExitToolError,
     PythonTool,
+    PythonToolInput,
+    PythonToolOutput,
     PythonToolError
 );

--- a/llm-chain/src/tools/tools/bash.rs
+++ b/llm-chain/src/tools/tools/bash.rs
@@ -1,5 +1,6 @@
 use crate::tools::description::{Describe, Format, ToolDescription};
-use crate::tools::tool::{gen_invoke_function, Tool, ToolError};
+use crate::tools::tool::{Tool, ToolError};
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::num::TryFromIntError;
 use std::process::Command;
@@ -66,8 +67,12 @@ pub enum BashToolError {
 
 impl ToolError for BashToolError {}
 
-impl BashTool {
-    fn invoke_typed(&self, input: &BashToolInput) -> Result<BashToolOutput, BashToolError> {
+#[async_trait]
+impl Tool for BashTool {
+    type Input = BashToolInput;
+    type Output = BashToolOutput;
+    type Error = BashToolError;
+    async fn invoke_typed(&self, input: &BashToolInput) -> Result<BashToolOutput, BashToolError> {
         let output = Command::new("bash").arg("-c").arg(&input.cmd).output()?;
 
         Ok(BashToolOutput {
@@ -80,11 +85,7 @@ impl BashTool {
             stdout: String::from_utf8(output.stdout)?,
         })
     }
-}
 
-impl Tool for BashTool {
-    type Error = BashToolError;
-    gen_invoke_function!();
     fn description(&self) -> ToolDescription {
         ToolDescription::new(
             "BashTool",

--- a/llm-chain/src/tools/tools/exit.rs
+++ b/llm-chain/src/tools/tools/exit.rs
@@ -1,5 +1,6 @@
 use crate::tools::description::{Describe, Format, ToolDescription};
-use crate::tools::tool::{gen_invoke_function, Tool, ToolError};
+use crate::tools::tool::{Tool, ToolError};
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -51,17 +52,15 @@ pub enum ExitToolError {
 
 impl ToolError for ExitToolError {}
 
-impl ExitTool {
+#[async_trait]
+impl Tool for ExitTool {
+    type Input = ExitToolInput;
+    type Output = ExitToolOutput;
+    type Error = ExitToolError;
     /// Invokes the `ExitTool` with the provided input.
-    fn invoke_typed(&self, input: &ExitToolInput) -> Result<ExitToolOutput, ExitToolError> {
+    async fn invoke_typed(&self, input: &ExitToolInput) -> Result<ExitToolOutput, ExitToolError> {
         std::process::exit(input.status_code);
     }
-}
-
-impl Tool for ExitTool {
-    type Error = ExitToolError;
-    gen_invoke_function!();
-
     /// Returns a `ToolDescription` for `ExitTool`.
     fn description(&self) -> ToolDescription {
         ToolDescription::new(

--- a/llm-chain/src/tools/tools/mod.rs
+++ b/llm-chain/src/tools/tools/mod.rs
@@ -4,6 +4,10 @@
 mod bash;
 mod exit;
 mod python;
-pub use bash::{BashTool, BashToolError};
-pub use exit::{ExitTool, ExitToolError};
-pub use python::{PythonTool, PythonToolError};
+mod vectorstore;
+pub use bash::{BashTool, BashToolError, BashToolInput, BashToolOutput};
+pub use exit::{ExitTool, ExitToolError, ExitToolInput, ExitToolOutput};
+pub use python::{PythonTool, PythonToolError, PythonToolInput, PythonToolOutput};
+pub use vectorstore::{
+    VectorStoreTool, VectorStoreToolError, VectorStoreToolInput, VectorStoreToolOutput,
+};

--- a/llm-chain/src/tools/tools/python.rs
+++ b/llm-chain/src/tools/tools/python.rs
@@ -1,5 +1,6 @@
 use crate::tools::description::{Describe, Format, ToolDescription};
-use crate::tools::tool::{gen_invoke_function, Tool, ToolError};
+use crate::tools::tool::{Tool, ToolError};
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 use thiserror::Error;
@@ -55,8 +56,13 @@ pub enum PythonToolError {
 
 impl ToolError for PythonToolError {}
 
-impl PythonTool {
-    fn invoke_typed(&self, input: &PythonToolInput) -> Result<PythonToolOutput, PythonToolError> {
+#[async_trait]
+impl Tool for PythonTool {
+    type Input = PythonToolInput;
+    type Output = PythonToolOutput;
+    type Error = PythonToolError;
+
+    async fn invoke_typed(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
         let output = Command::new("python3")
             .arg("-c")
             .arg(&input.code)
@@ -66,11 +72,7 @@ impl PythonTool {
             stderr: String::from_utf8(output.stderr).unwrap(),
         })
     }
-}
 
-impl Tool for PythonTool {
-    type Error = PythonToolError;
-    gen_invoke_function!();
     fn description(&self) -> ToolDescription {
         ToolDescription::new(
             "PythonTool",

--- a/llm-chain/src/tools/tools/vectorstore.rs
+++ b/llm-chain/src/tools/tools/vectorstore.rs
@@ -1,0 +1,140 @@
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{
+    schema::EmptyMetadata,
+    tools::{Describe, Format, Tool, ToolDescription, ToolError},
+    traits::{Embeddings, VectorStore, VectorStoreError},
+};
+
+pub struct VectorStoreTool<E, V, M = EmptyMetadata>
+where
+    E: Embeddings,
+    V: VectorStore<E, M>,
+{
+    pub store: V,
+    pub topic: String,
+    pub topic_context: String,
+    _data1: PhantomData<E>,
+    _data2: PhantomData<M>,
+}
+
+impl<E, V, M> VectorStoreTool<E, V, M>
+where
+    E: Embeddings,
+    V: VectorStore<E, M>,
+{
+    pub fn new(store: V, topic: &str, topic_context: &str) -> Self {
+        Self {
+            store,
+            topic: topic.to_string(),
+            topic_context: topic_context.to_string(),
+            _data1: Default::default(),
+            _data2: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum VectorStoreToolError<E>
+where
+    E: std::fmt::Debug + std::error::Error + VectorStoreError,
+{
+    #[error(transparent)]
+    YamlError(#[from] serde_yaml::Error),
+    #[error(transparent)]
+    VectorStoreError(#[from] E),
+}
+
+impl<E> ToolError for VectorStoreToolError<E> where
+    E: std::fmt::Debug + std::error::Error + VectorStoreError
+{
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VectorStoreToolInput {
+    query: String,
+    limit: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VectorStoreToolOutput {
+    texts: Vec<String>,
+}
+
+impl Describe for VectorStoreToolInput {
+    fn describe() -> Format {
+        vec![
+            (
+                "query",
+                "You can search for texts similar to this one in the vector database.",
+            )
+                .into(),
+            (
+                "limit",
+                "The number of texts that will be returned from the vector database.",
+            )
+                .into(),
+        ]
+        .into()
+    }
+}
+
+impl Describe for VectorStoreToolOutput {
+    fn describe() -> Format {
+        vec![
+            ("texts", "List of texts similar to the query.").into(),
+            (
+                "error_msg",
+                "Error message received when trying to search in the vector database.",
+            )
+                .into(),
+        ]
+        .into()
+    }
+}
+
+#[async_trait]
+impl<E, V, M> Tool for VectorStoreTool<E, V, M>
+where
+    E: Embeddings + Sync + Send,
+    V: VectorStore<E, M> + Sync + Send,
+    M: Sync + Send,
+    Self: 'static,
+{
+    type Input = VectorStoreToolInput;
+    type Output = VectorStoreToolOutput;
+    type Error = VectorStoreToolError<<V as VectorStore<E, M>>::Error>;
+
+    async fn invoke_typed(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
+        match self
+            .store
+            .similarity_search(input.query.clone(), input.limit)
+            .await
+        {
+            Ok(o) => Ok(VectorStoreToolOutput {
+                texts: o.into_iter().map(|d| d.page_content).collect(),
+            }),
+            Err(e) => Err(<<V as VectorStore<E, M>>::Error as Into<Self::Error>>::into(e)),
+        }
+    }
+
+    fn description(&self) -> crate::tools::ToolDescription {
+        ToolDescription::new(
+            "VectorStoreTool",
+            "A tool that retrieves documents based on similarity to a given query.",
+            &format!(
+                "Useful for when you need to answer questions about {}. 
+            Whenever you need information about {} 
+            you should ALWAYS use this. 
+            Input should be a fully formed question.",
+                self.topic, self.topic_context
+            ),
+            Self::Input::describe(),
+            Self::Output::describe(),
+        )
+    }
+}

--- a/llm-chain/src/traits.rs
+++ b/llm-chain/src/traits.rs
@@ -170,12 +170,15 @@ pub trait Embeddings {
     async fn embed_query(&self, query: String) -> Result<Vec<f32>, Self::Error>;
 }
 
+/// This marker trait is needed so users of VectorStore can derive From<VectorStore::Error>
+pub trait VectorStoreError {}
+
 #[async_trait]
 pub trait VectorStore<E, M = EmptyMetadata>
 where
     E: Embeddings,
 {
-    type Error: Debug + Error + From<<E as Embeddings>::Error>;
+    type Error: Debug + Error + VectorStoreError + From<<E as Embeddings>::Error>;
     async fn add_texts(&self, texts: Vec<String>) -> Result<Vec<String>, Self::Error>;
     async fn add_documents(&self, documents: Vec<Document<M>>) -> Result<Vec<String>, Self::Error>;
     async fn similarity_search(

--- a/llm-chain/src/traits.rs
+++ b/llm-chain/src/traits.rs
@@ -178,7 +178,7 @@ pub trait VectorStore<E, M = EmptyMetadata>
 where
     E: Embeddings,
 {
-    type Error: Debug + Error + VectorStoreError + From<<E as Embeddings>::Error>;
+    type Error: Debug + Error + VectorStoreError;
     async fn add_texts(&self, texts: Vec<String>) -> Result<Vec<String>, Self::Error>;
     async fn add_documents(&self, documents: Vec<Document<M>>) -> Result<Vec<String>, Self::Error>;
     async fn similarity_search(

--- a/llm-chain/src/vectorstores/qdrant.rs
+++ b/llm-chain/src/vectorstores/qdrant.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use crate::{
     schema::{Document, EmptyMetadata},
-    traits::{Embeddings, EmbeddingsError, VectorStore},
+    traits::{Embeddings, EmbeddingsError, VectorStore, VectorStoreError},
 };
 
 const DEFAULT_CONTENT_PAYLOAD_KEY: &str = "page_content";
@@ -51,7 +51,7 @@ where
 impl<E, M> Qdrant<E, M>
 where
     E: Embeddings,
-    M: TryFrom<Value>,
+    M: TryFrom<Value> + Into<Value> + Send + Sync,
 {
     pub fn new(
         client: Arc<QdrantClient>,
@@ -143,6 +143,11 @@ where
     Client(#[from] anyhow::Error),
     #[error(transparent)]
     ConversionError(#[from] ConversionError),
+}
+
+impl<E> VectorStoreError for QdrantError<E> where
+    E: std::fmt::Debug + std::error::Error + EmbeddingsError
+{
 }
 
 #[async_trait]

--- a/llm-chain/src/vectorstores/qdrant.rs
+++ b/llm-chain/src/vectorstores/qdrant.rs
@@ -35,10 +35,10 @@ impl From<EmptyMetadata> for Value {
     }
 }
 
-pub struct Qdrant<E, M = EmptyMetadata>
+pub struct Qdrant<E, M>
 where
     E: Embeddings,
-    M: TryFrom<Value>,
+    M: TryFrom<Value> + Into<Value> + Send + Sync,
 {
     client: Arc<QdrantClient>,
     collection_name: String,


### PR DESCRIPTION
Make Tool invocations async to accomodate calling VectorStore methods in Tool; remove gen_invoke_function! as inline macros do not work with async_trait; move invoke_typed() into Tool trait; add Input and Output associated types to multitool! macro; adjust examples; WIP: conflicting implementations for QdrantTool - try implementing VectorStore in llm-chain-openai for concrete Embeddings

FIXES:
- prompt parameters were not passed to ChatGPT executor