### PR TITLE
Use text splitter for chunking docs

### DIFF
--- a/llm-chain-llama/src/text_splitter.rs
+++ b/llm-chain-llama/src/text_splitter.rs
@@ -1,6 +1,7 @@
 use llm_chain::text_splitter::TextSplitter;
 use llm_chain::tokens::{Tokenizer, TokenizerError};
 
+use crate::Executor;
 use crate::{
     context::LLamaContext,
     tokenizer::{embedding_to_output, llama_tokenize_helper},
@@ -8,6 +9,14 @@ use crate::{
 
 pub struct LLamaTextSplitter<'a> {
     context: &'a LLamaContext,
+}
+
+impl<'a> LLamaTextSplitter<'a> {
+    pub fn new(exec: &'a Executor) -> Self {
+        Self {
+            context: exec.get_context(),
+        }
+    }
 }
 
 impl<'a> Tokenizer<i32> for LLamaTextSplitter<'a> {

--- a/llm-chain-openai/src/chatgpt/step.rs
+++ b/llm-chain-openai/src/chatgpt/step.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 /// let custom_model = Model::Other("your_custom_model_name".to_string());
 /// ```
 ///
+#[derive(Clone)]
 #[cfg_attr(feature = "serialization", derive(Serialize, Deserialize))]
 pub enum Model {
     ChatGPT3_5Turbo,

--- a/llm-chain/src/chains/map_reduce.rs
+++ b/llm-chain/src/chains/map_reduce.rs
@@ -173,7 +173,7 @@ impl<S: Step> Chain<S> {
                     <E as traits::Executor>::Output,
                     <E as traits::Executor>::Token,
                     <E as traits::Executor>::StepTokenizer<'a>,
-                >>::split_to_fit(executor, step, x)
+                >>::split_to_fit(executor, step, x, None)
             })
             .collect();
         let data = data?.iter().flatten().cloned().collect();

--- a/llm-chain/src/traits.rs
+++ b/llm-chain/src/traits.rs
@@ -16,7 +16,7 @@ use crate::{
     output::Output,
     schema::{Document, EmptyMetadata},
     tokens::{PromptTokensError, TokenCount, Tokenizer, TokenizerError},
-    Parameters,
+    Parameters, TextSplitter,
 };
 use async_trait::async_trait;
 
@@ -94,6 +94,10 @@ pub trait Executor {
     where
         Self: 'a;
 
+    type TextSplitter<'a>: TextSplitter<Self::Token>
+    where
+        Self: 'a;
+
     /// Executes the given input and returns the resulting output.
     ///
     /// # Parameters
@@ -127,6 +131,16 @@ pub trait Executor {
         parameters: &Parameters,
     ) -> Result<TokenCount, PromptTokensError>;
 
+    /// Returns the maximum number of input tokens allowed by the model used in step.
+    ///
+    /// # Parameters
+    ///
+    /// * `step`: The step to get token allowance for.
+    ///
+    /// # Returns
+    /// The max token count for the step
+    fn max_tokens_allowed(&self, step: &Self::Step) -> i32;
+
     /// Creates a tokenizer, depending on the model used by `step`.
     ///
     /// # Parameters
@@ -137,6 +151,16 @@ pub trait Executor {
     ///
     /// A `Result` containing a tokenizer, or an error if there was a problem.
     fn get_tokenizer(&self, step: &Self::Step) -> Result<Self::StepTokenizer<'_>, TokenizerError>;
+
+    /// Creates a text splitter, depending on the model used by 'step'
+    ///
+    /// # Parameters
+    ///
+    /// * `step` The step to get an associated text splitter for.
+    ///
+    /// # Returns
+    /// A `Result` containing a text splitter, or an error if there was a problem.
+    fn get_text_splitter(&self, step: &Self::Step) -> Result<Self::TextSplitter<'_>, Self::Error>;
 }
 
 /// This marker trait is needed so the concrete VectorStore::Error can have a derived From<Embeddings::Error>


### PR DESCRIPTION
Hey Will.

Tried to implement the last part of my previous PR,  actually using TextSplitters to chunk Paremeters that are too large for model context.
I'm not sure if this the direction you imagined, but I'm happy to do any changes needed.