### PR TITLE
OpenAI streaming update

### DIFF
--- a/llm-chain-openai/src/chatgpt/output.rs
+++ b/llm-chain-openai/src/chatgpt/output.rs
@@ -25,7 +25,7 @@ use async_openai::types::{ChatCompletionResponseStream, CreateChatCompletionResp
 use async_trait::async_trait;
 use llm_chain::output;
 use std::fmt;
-use stream::{SharedResponseStream, StreamWrapper};
+use stream::{ResponseStream, StreamWrapper};
 
 /// Represents the output of a CreateChatCompletionResponse from OpenAI.
 #[derive(Clone, Debug)]
@@ -51,7 +51,7 @@ impl From<ChatCompletionResponseStream> for OutputInner {
 pub struct Output(OutputInner);
 
 impl Output {
-    pub fn as_stream(&self) -> Option<SharedResponseStream> {
+    pub fn as_stream(&self) -> Option<ResponseStream> {
         match &self.0 {
             OutputInner::Stream(wrapper) => Some(wrapper.inner()),
             _ => None,


### PR DESCRIPTION
Refactor openai module's Ouput stream variant to overwrite the stream during primary choices call such that the method can be invoked many times.