### PR TITLE
Fix: map-reduce failing

### DIFF
--- a/llm-chain-openai/src/chatgpt/executor.rs
+++ b/llm-chain-openai/src/chatgpt/executor.rs
@@ -111,13 +111,18 @@ impl traits::Executor for Executor {
             tokens_used as i32,
         ))
     }
-
     /// Get the context size from the model or return default context size
     fn max_tokens_allowed(&self, opts: Option<&PerInvocation>) -> i32 {
         let model = self.get_model_from_invocation_options(opts);
         tiktoken_rs::model::get_context_size(&model.to_string())
             .try_into()
             .unwrap_or(4096)
+    }
+
+    fn answer_prefix(
+        &self,
+        _prompt: &Prompt) -> Option<String> {
+        None
     }
 
     fn get_tokenizer(

--- a/llm-chain/src/agents/self_ask_with_search.rs
+++ b/llm-chain/src/agents/self_ask_with_search.rs
@@ -54,7 +54,7 @@ So the final answer is: No
 Question: {{input}}
 Are followup questions needed here:{{agent_scratchpad}}";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AgentAction {
     pub tool: String,
     pub tool_input: serde_yaml::Value,
@@ -403,6 +403,7 @@ mod tests {
         tools::{Tool, ToolError},
         traits::{Executor, ExecutorError, Options},
         TextSplitter,
+        prompt::Prompt
     };
 
     use super::{
@@ -593,6 +594,14 @@ mod tests {
             ) -> Result<crate::tokens::TokenCount, crate::tokens::PromptTokensError> {
                 todo!()
             }
+
+
+            fn answer_prefix(
+                &self,
+                _prompt: &Prompt) -> Option<String> {
+                todo!()
+            }
+
 
             fn max_tokens_allowed(&self, _: Option<&Self::PerInvocationOptions>) -> i32 {
                 todo!()

--- a/llm-chain/src/chains/map_reduce.rs
+++ b/llm-chain/src/chains/map_reduce.rs
@@ -79,7 +79,7 @@ impl<E: Executor> Chain<E> {
         let map_frame = Frame::new(executor, &self.map);
         let reduce_frame = Frame::new(executor, &self.reduce);
 
-        let chunked_docs = self.chunk_documents(documents.clone(), executor, &self.map)?;
+        let chunked_docs = self.chunk_documents(documents.clone(), base_parameters.clone(), executor, &self.map)?;
 
         // Execute the `map` step for each document, combining the base parameters with each document's parameters.
         let chunked_docs_with_base_parameters: Vec<_> = chunked_docs
@@ -155,6 +155,7 @@ impl<E: Executor> Chain<E> {
     fn chunk_documents<'a>(
         &self,
         v: Vec<Parameters>,
+        base_parameters: Parameters,
         executor: &E,
         step: &Step<E>,
     ) -> Result<Vec<Parameters>, PromptTokensError>
@@ -168,7 +169,7 @@ impl<E: Executor> Chain<E> {
                     <E as traits::Executor>::Output,
                     <E as traits::Executor>::Token,
                     <E as traits::Executor>::StepTokenizer<'a>,
-                >>::split_to_fit(executor, step, x, None)
+                >>::split_to_fit(executor, step, x, &base_parameters, None)
             })
             .collect();
         let data = data?.iter().flatten().cloned().collect();

--- a/llm-chain/src/prompt/string_template/tera.rs
+++ b/llm-chain/src/prompt/string_template/tera.rs
@@ -5,5 +5,5 @@ use crate::Parameters;
 // Renders the given `template` using the `context` provided as `Parameters`.
 // Returns a `Result` with a `String` containing the rendered template or an error.
 pub fn render(template: &str, context: &Parameters) -> Result<String, tera::Error> {
-    Tera::one_off(template, &context.to_tera(), true)
+    Tera::one_off(template, &context.to_tera(), false)
 }

--- a/llm-chain/src/traits.rs
+++ b/llm-chain/src/traits.rs
@@ -109,6 +109,18 @@ pub trait Executor: Sized {
     /// The max token count for the step
     fn max_tokens_allowed(&self, options: Option<&Self::PerInvocationOptions>) -> i32;
 
+    
+    /// Returns a possible answer prefix inserted by the model, during a certain prompt mode
+    ///
+    /// # Parameters
+    ///
+    /// * `prompt`: The prompt passed into step
+    ///
+    /// # Returns
+    ///
+    /// A `Option` containing a String if  prefix exists, or none if there is no prefix
+    fn answer_prefix(&self, prompt: &Prompt) -> Option<String>;
+
     /// Creates a tokenizer, depending on the model used by `step`.
     ///
     /// # Parameters
@@ -117,7 +129,6 @@ pub trait Executor: Sized {
     ///
     /// # Returns
     ///
-
     /// A `Result` containing a tokenizer, or an error if there was a problem.
     fn get_tokenizer(
         &self,


### PR DESCRIPTION
Autoescpaing for tera turned off. Resulted in inconsistent token counts.
base_parameters added to prompt when counting tokens used.
answer_prefix is injected into tokens used if using Chat(_) in llama models.

Note: We're currently not supporting templated documents.

