### PR TITLE
Add is_streaming to create_chat_completion_request

### DIFF
--- a/llm-chain-llama/src/executor.rs
+++ b/llm-chain-llama/src/executor.rs
@@ -185,6 +185,7 @@ impl ExecutorTrait for Executor {
         &self,
         options: Option<&Self::PerInvocationOptions>,
         prompt: &Prompt,
+        is_streaming: Option<bool>,
     ) -> Result<Self::Output, Self::Error> {
         let config = match options {
             Some(options) => options.clone(),

--- a/llm-chain/src/agents/self_ask_with_search.rs
+++ b/llm-chain/src/agents/self_ask_with_search.rs
@@ -342,7 +342,7 @@ where
         let prompt = PromptTemplate::Text(PROMPT.into()).format(&template_parameters)?;
         let plan = self
             .executor
-            .execute(None, &prompt)
+            .execute(None, &prompt, None)
             .await
             .map_err(SelfAskWithSearchAgentError::ExecutorError)?;
         plan.primary_textual_output()
@@ -575,6 +575,7 @@ mod tests {
                 &self,
                 _: Option<&Self::PerInvocationOptions>,
                 _: &crate::prompt::Prompt,
+                _: Option<bool>,
             ) -> Result<Self::Output, Self::Error> {
                 todo!()
             }

--- a/llm-chain/src/chains/conversation.rs
+++ b/llm-chain/src/chains/conversation.rs
@@ -77,7 +77,8 @@ impl<E: traits::Executor> Chain<E> {
         exec: &E,
     ) -> Result<E::Output, Error<E::Error>> {
         let fmt = step.format(parameters)?;
-        self.send_message_raw(step.options(), &fmt, step.is_streaming(), exec).await
+        self.send_message_raw(step.options(), &fmt, step.is_streaming(), exec)
+            .await
     }
 
     /// Sends a message to the LLM and returns the response.
@@ -107,7 +108,9 @@ impl<E: traits::Executor> Chain<E> {
         let prompt_with_history = Prompt::Chat(self.state.clone()).combine(prompt);
 
         // Execute the prompt and retrieve the LLM's response.
-        let res = exec.execute(options, &prompt_with_history, is_streaming).await?;
+        let res = exec
+            .execute(options, &prompt_with_history, is_streaming)
+            .await?;
 
         // Create a ChatMessage from the response and add it to the conversation state.
         let response_message = ChatMessage::new(

--- a/llm-chain/src/chains/conversation.rs
+++ b/llm-chain/src/chains/conversation.rs
@@ -77,7 +77,7 @@ impl<E: traits::Executor> Chain<E> {
         exec: &E,
     ) -> Result<E::Output, Error<E::Error>> {
         let fmt = step.format(parameters)?;
-        self.send_message_raw(step.options(), &fmt, exec).await
+        self.send_message_raw(step.options(), &fmt, step.is_streaming(), exec).await
     }
 
     /// Sends a message to the LLM and returns the response.
@@ -95,6 +95,7 @@ impl<E: traits::Executor> Chain<E> {
         &mut self,
         options: Option<&<E as traits::Executor>::PerInvocationOptions>,
         prompt: &Prompt,
+        is_streaming: Option<bool>,
         exec: &E,
     ) -> Result<E::Output, Error<E::Error>> {
         let tok = exec.tokens_used(options, prompt)?;
@@ -106,7 +107,7 @@ impl<E: traits::Executor> Chain<E> {
         let prompt_with_history = Prompt::Chat(self.state.clone()).combine(prompt);
 
         // Execute the prompt and retrieve the LLM's response.
-        let res = exec.execute(options, &prompt_with_history).await?;
+        let res = exec.execute(options, &prompt_with_history, is_streaming).await?;
 
         // Create a ChatMessage from the response and add it to the conversation state.
         let response_message = ChatMessage::new(

--- a/llm-chain/src/frame.rs
+++ b/llm-chain/src/frame.rs
@@ -45,7 +45,10 @@ where
         parameters: &Parameters,
     ) -> Result<E::Output, FormatAndExecuteError<E::Error>> {
         let prompt = self.step.format(parameters)?;
-        Ok(self.executor.execute(self.step.options(), &prompt, self.step.is_streaming()).await?)
+        Ok(self
+            .executor
+            .execute(self.step.options(), &prompt, self.step.is_streaming())
+            .await?)
     }
 }
 

--- a/llm-chain/src/frame.rs
+++ b/llm-chain/src/frame.rs
@@ -45,7 +45,7 @@ where
         parameters: &Parameters,
     ) -> Result<E::Output, FormatAndExecuteError<E::Error>> {
         let prompt = self.step.format(parameters)?;
-        Ok(self.executor.execute(self.step.options(), &prompt).await?)
+        Ok(self.executor.execute(self.step.options(), &prompt, self.step.is_streaming()).await?)
     }
 }
 

--- a/llm-chain/src/traits.rs
+++ b/llm-chain/src/traits.rs
@@ -78,6 +78,7 @@ pub trait Executor: Sized {
         &self,
         options: Option<&Self::PerInvocationOptions>,
         prompt: &Prompt,
+        is_streaming: Option<bool>,
     ) -> Result<Self::Output, Self::Error>;
 
     /// Calculates the number of tokens used by the step given a set of parameters.


### PR DESCRIPTION
I was trying out chat streaming and realized it didn't work - `Output.as_stream` was returning None. Decided to find the issue and fix. I am very new to Rust so do guide me on what I am missing to get the PR merged.

Alternatively, if the design is not what was intended, feel free to explain and reject the PR.