### PR TITLE
docs: Update the version in  README, "Getting Started" section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,8 +43,8 @@ To start using `llm-chain`, add it as a dependency in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-llm-chain = "0.8.0"
-llm-chain-openai = "0.8.0
+llm-chain = "0.11.1"
+llm-chain-openai = "0.11.1"
 ```
 
 The examples for `llm-chain-openai` require you to set the `OPENAI_API_KEY` environment variable which you can do like this:


### PR DESCRIPTION
It was 0.8.0, updated to 0.11.1.