### PR TITLE
Implement Embeddings::for_client for llm-chain-openai

### DIFF
--- a/crates/llm-chain-openai/src/embeddings.rs
+++ b/crates/llm-chain-openai/src/embeddings.rs
@@ -65,3 +65,15 @@ impl Default for Embeddings {
         }
     }
 }
+
+impl Embeddings {
+    pub fn for_client(
+        client: async_openai::Client,
+        model: &str,
+    ) -> Self {
+        Self {
+            client: client.into(),
+            model: model.to_string(),
+        }
+    }
+}

--- a/crates/llm-chain-openai/src/embeddings.rs
+++ b/crates/llm-chain-openai/src/embeddings.rs
@@ -67,10 +67,7 @@ impl Default for Embeddings {
 }
 
 impl Embeddings {
-    pub fn for_client(
-        client: async_openai::Client,
-        model: &str,
-    ) -> Self {
+    pub fn for_client(client: async_openai::Client, model: &str) -> Self {
         Self {
             client: client.into(),
             model: model.to_string(),


### PR DESCRIPTION
As per title, this allows overriding of the async-openai client for embedding use case.
