### PR TITLE
[hnsw] Allow more flexibility in id generation for document stores

### DIFF
--- a/crates/llm-chain-hnsw/examples/dump_load.rs
+++ b/crates/llm-chain-hnsw/examples/dump_load.rs
@@ -16,7 +16,7 @@ async fn main() {
     let hnsw_index_fn = "hnsw_index".to_string();
     let mut embeddings = llm_chain_openai::embeddings::Embeddings::default();
     let document_store = Arc::new(Mutex::new(InMemoryDocumentStore::<EmptyMetadata>::new()));
-    let mut hnsw_vs = HnswVectorStore::new(HnswArgs::default(), embeddings, document_store.clone());
+    let mut hnsw_vs = HnswVectorStore::new(HnswArgs::default(), Arc::new(embeddings), document_store.clone());
 
     // Storing documents
 
@@ -53,7 +53,7 @@ async fn main() {
     println!("Loading hnsw index from file");
     embeddings = llm_chain_openai::embeddings::Embeddings::default();
     hnsw_vs =
-        HnswVectorStore::load_from_file(hnsw_index_fn, embeddings, document_store.clone()).unwrap();
+        HnswVectorStore::load_from_file(hnsw_index_fn, Arc::new(embeddings), document_store.clone()).unwrap();
     println!("Loaded!");
 
     let response = hnsw_vs

--- a/crates/llm-chain-hnsw/examples/dump_load.rs
+++ b/crates/llm-chain-hnsw/examples/dump_load.rs
@@ -16,7 +16,11 @@ async fn main() {
     let hnsw_index_fn = "hnsw_index".to_string();
     let mut embeddings = llm_chain_openai::embeddings::Embeddings::default();
     let document_store = Arc::new(Mutex::new(InMemoryDocumentStore::<EmptyMetadata>::new()));
-    let mut hnsw_vs = HnswVectorStore::new(HnswArgs::default(), Arc::new(embeddings), document_store.clone());
+    let mut hnsw_vs = HnswVectorStore::new(
+        HnswArgs::default(),
+        Arc::new(embeddings),
+        document_store.clone(),
+    );
 
     // Storing documents
 
@@ -52,8 +56,12 @@ async fn main() {
     // Load
     println!("Loading hnsw index from file");
     embeddings = llm_chain_openai::embeddings::Embeddings::default();
-    hnsw_vs =
-        HnswVectorStore::load_from_file(hnsw_index_fn, Arc::new(embeddings), document_store.clone()).unwrap();
+    hnsw_vs = HnswVectorStore::load_from_file(
+        hnsw_index_fn,
+        Arc::new(embeddings),
+        document_store.clone(),
+    )
+    .unwrap();
     println!("Loaded!");
 
     let response = hnsw_vs

--- a/crates/llm-chain-hnsw/examples/similarity_search.rs
+++ b/crates/llm-chain-hnsw/examples/similarity_search.rs
@@ -15,7 +15,7 @@ async fn main() {
     println!("OPENAI KEY: {}", std::env::var("OPENAI_API_KEY").unwrap());
     let embeddings = llm_chain_openai::embeddings::Embeddings::default();
     let document_store = Arc::new(Mutex::new(InMemoryDocumentStore::<EmptyMetadata>::new()));
-    let hnsw_vs = HnswVectorStore::new(HnswArgs::default(), embeddings, document_store);
+    let hnsw_vs = HnswVectorStore::new(HnswArgs::default(), Arc::new(embeddings), document_store);
 
     // Storing documents
 

--- a/crates/llm-chain-hnsw/src/lib.rs
+++ b/crates/llm-chain-hnsw/src/lib.rs
@@ -40,7 +40,7 @@ where
 {
     hnsw: Arc<Hnsw<f32, DistCosine>>,
     document_store: Arc<Mutex<D>>,
-    embeddings: E,
+    embeddings: Arc<E>,
     _marker: PhantomData<M>,
 }
 
@@ -50,7 +50,7 @@ where
     D: DocumentStore<usize, M> + Send + Sync,
     M: Send + Sync + Serialize + DeserializeOwned,
 {
-    pub fn new(hnsw_args: HnswArgs, embeddings: E, document_store: Arc<Mutex<D>>) -> Self {
+    pub fn new(hnsw_args: HnswArgs, embeddings: Arc<E>, document_store: Arc<Mutex<D>>) -> Self {
         let hnsw = Hnsw::new(
             hnsw_args.max_nb_connection,
             hnsw_args.max_elements,
@@ -77,7 +77,7 @@ where
 
     pub fn load_from_file(
         filename: String,
-        embeddings: E,
+        embeddings: Arc<E>,
         document_store: Arc<Mutex<D>>,
     ) -> Result<Self, HnswVectorStoreError<E::Error, D::Error>> {
         let graph_fn = String::from(format!("{}.hnsw.graph", &filename));

--- a/crates/llm-chain/src/document_stores/document_store.rs
+++ b/crates/llm-chain/src/document_stores/document_store.rs
@@ -17,8 +17,7 @@ where
 
     async fn next_id(&self) -> Result<T, Self::Error>;
 
-    async fn insert(&mut self, documents: &HashMap<T, Document<M>>)
-        -> Result<(), Self::Error>;
+    async fn insert(&mut self, documents: &HashMap<T, Document<M>>) -> Result<(), Self::Error>;
 }
 
 pub trait DocumentStoreError {}

--- a/crates/llm-chain/src/document_stores/document_store.rs
+++ b/crates/llm-chain/src/document_stores/document_store.rs
@@ -6,17 +6,18 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 
 #[async_trait]
-pub trait DocumentStore<M>
+pub trait DocumentStore<T, M>
 where
+    T: Send + Sync,
     M: Serialize + DeserializeOwned + Send + Sync,
 {
     type Error: std::fmt::Debug + std::error::Error + DocumentStoreError;
 
-    async fn get(&self, id: &str) -> Result<Option<Document<M>>, Self::Error>;
+    async fn get(&self, id: &T) -> Result<Option<Document<M>>, Self::Error>;
 
-    async fn len(&self) -> Result<usize, Self::Error>;
+    async fn next_id(&self) -> Result<T, Self::Error>;
 
-    async fn insert(&mut self, documents: &HashMap<String, Document<M>>)
+    async fn insert(&mut self, documents: &HashMap<T, Document<M>>)
         -> Result<(), Self::Error>;
 }
 

--- a/crates/llm-chain/src/document_stores/in_memory_document_store.rs
+++ b/crates/llm-chain/src/document_stores/in_memory_document_store.rs
@@ -99,10 +99,7 @@ where
         Ok(self.map.len())
     }
 
-    async fn insert(
-        &mut self,
-        documents: &HashMap<usize, Document<M>>,
-    ) -> Result<(), Self::Error> {
+    async fn insert(&mut self, documents: &HashMap<usize, Document<M>>) -> Result<(), Self::Error> {
         for (key, value) in documents.iter() {
             if self.map.contains_key(key) {
                 return Err(InMemoryDocumentStoreError::KeyConflict(key.to_string()));

--- a/crates/llm-chain/src/document_stores/in_memory_document_store.rs
+++ b/crates/llm-chain/src/document_stores/in_memory_document_store.rs
@@ -70,14 +70,14 @@ pub struct InMemoryDocumentStore<M>
 where
     M: Serialize + DeserializeOwned + Send + Sync,
 {
-    map: HashMap<String, InMemoryDocument<M>>,
+    map: HashMap<usize, InMemoryDocument<M>>,
 }
 
 impl<M> InMemoryDocumentStore<M>
 where
     M: Serialize + DeserializeOwned + Send + Sync,
 {
-    pub fn new() -> InMemoryDocumentStore<M> {
+    pub fn new() -> Self {
         InMemoryDocumentStore {
             map: HashMap::new(),
         }
@@ -85,23 +85,23 @@ where
 }
 
 #[async_trait]
-impl<M> DocumentStore<M> for InMemoryDocumentStore<M>
+impl<M> DocumentStore<usize, M> for InMemoryDocumentStore<M>
 where
     M: Serialize + DeserializeOwned + Send + Sync,
 {
     type Error = InMemoryDocumentStoreError;
 
-    async fn get(&self, id: &str) -> Result<Option<Document<M>>, Self::Error> {
+    async fn get(&self, id: &usize) -> Result<Option<Document<M>>, Self::Error> {
         Ok(self.map.get(id).map(|m| m.into()))
     }
 
-    async fn len(&self) -> Result<usize, Self::Error> {
+    async fn next_id(&self) -> Result<usize, Self::Error> {
         Ok(self.map.len())
     }
 
     async fn insert(
         &mut self,
-        documents: &HashMap<String, Document<M>>,
+        documents: &HashMap<usize, Document<M>>,
     ) -> Result<(), Self::Error> {
         for (key, value) in documents.iter() {
             if self.map.contains_key(key) {


### PR DESCRIPTION
- No longer force document store to have an id of type usize, only hnsw vector store should use usize
- Wrap embedding ref in an Arc