### PR TITLE
 Opt for num_gpu_layers

### DIFF
--- a/crates/llm-chain-llama/src/options.rs
+++ b/crates/llm-chain-llama/src/options.rs
@@ -102,14 +102,17 @@ lazy_static! {
         MirostatTau: 5.0,
         MirostatEta: 0.1,
         PenalizeNl: true,
-        StopSequence: vec!["\n\n".to_string()]
+        StopSequence: vec!["\n\n".to_string()],
+        NumGpuLayers: 0
     );
 }
 
 pub(crate) fn get_executor_initial_opts(opt: &OptionsCascade) -> Option<(String, ContextParams)> {
     opt_extract!(opt, model, Model);
     opt_extract!(opt, max_context_size, MaxContextSize);
+    opt_extract!(opt, num_gpu_layers, NumGpuLayers);
     let mut cp = ContextParams::new();
     cp.n_ctx = *max_context_size as i32;
+    cp.n_gpu_layers = *num_gpu_layers;
     Some((model.to_path(), cp))
 }

--- a/crates/llm-chain/src/options.rs
+++ b/crates/llm-chain/src/options.rs
@@ -394,6 +394,10 @@ pub enum Opt {
     User(String),
     /// The type of the model.
     ModelType(String),
+
+    /// Number of layers to pass to the GPU for llm-chain-llama.
+    /// Only makes sense if CUBLAS is enabled.
+    NumGpuLayers(i32),
 }
 
 // Helper function to extract environment variables


### PR DESCRIPTION
I didn't see any way to set the number of layers passed to the gpu for llama. I don't know rust so this might be the wrong way to do things.

After setting the enabling the `cuda` feature for `llm-chain-llama-sys` then setting `NumGpuLayers` option to any number above 0 cuda acceleration works perfectly for me and llama models run like 5x faster at 20 layers.

It doesn't seem to break anything as setting the option with `cuda` disabled just has no effect.