### PR TITLE
Updated llama.cpp, don't segfault on missing file, and fixed OutputStream hanging forever

### DIFF
--- a/crates/llm-chain-llama/src/context.rs
+++ b/crates/llm-chain-llama/src/context.rs
@@ -106,11 +106,14 @@ pub(crate) struct LLamaContext {
 
 impl LLamaContext {
     // Creates a new LLamaContext from the specified file and configuration parameters.
-    pub fn from_file_and_params(path: &str, params: Option<&ContextParams>) -> Self {
+    pub fn from_file_and_params(path: &str, params: Option<&ContextParams>) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let path = CString::new(path).expect("could not convert to CString");
         let params = ContextParams::or_default(params);
         let ctx = unsafe { llama_init_from_file(path.into_raw() as *const i8, params) };
-        Self { ctx }
+        if ctx.is_null() {
+            return Err("Initializing llama context returned nullptr".into());
+        }
+        Ok(Self { ctx })
     }
 
     // Token logits obtained from the last call to llama_eval()

--- a/crates/llm-chain-llama/src/context.rs
+++ b/crates/llm-chain-llama/src/context.rs
@@ -112,7 +112,10 @@ pub(crate) struct LLamaContext {
 
 impl LLamaContext {
     // Creates a new LLamaContext from the specified file and configuration parameters.
-    pub fn from_file_and_params(path: &str, params: Option<&ContextParams>) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub fn from_file_and_params(
+        path: &str,
+        params: Option<&ContextParams>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let path = CString::new(path).expect("could not convert to CString");
         let params = ContextParams::or_default(params);
         let ctx = unsafe { llama_init_from_file(path.into_raw() as *const i8, params) };

--- a/crates/llm-chain-llama/src/context.rs
+++ b/crates/llm-chain-llama/src/context.rs
@@ -30,12 +30,13 @@ pub struct ContextParams {
     pub n_gpu_layers: i32,
     pub main_gpu: i32,
     pub tensor_split: [f32; LLAMA_MAX_DEVICES],
-    pub seed: i32,
+    pub seed: u32,
     pub f16_kv: bool,
     pub vocab_only: bool,
     pub use_mlock: bool,
     pub use_mmap: bool,
     pub embedding: bool,
+    pub low_vram: bool,
 }
 
 impl ContextParams {
@@ -74,6 +75,7 @@ impl From<ContextParams> for llama_context_params {
             embedding: params.embedding,
             progress_callback: None,
             progress_callback_user_data: null_mut(),
+            low_vram: params.low_vram,
         }
     }
 }
@@ -92,6 +94,7 @@ impl From<llama_context_params> for ContextParams {
             use_mlock: params.use_mlock,
             use_mmap: params.use_mmap,
             embedding: params.embedding,
+            low_vram: params.low_vram,
         }
     }
 }

--- a/crates/llm-chain-llama/src/context.rs
+++ b/crates/llm-chain-llama/src/context.rs
@@ -37,6 +37,8 @@ pub struct ContextParams {
     pub use_mmap: bool,
     pub embedding: bool,
     pub low_vram: bool,
+    pub rope_freq_base: f32,
+    pub rope_freq_scale: f32,
 }
 
 impl ContextParams {
@@ -76,6 +78,8 @@ impl From<ContextParams> for llama_context_params {
             progress_callback: None,
             progress_callback_user_data: null_mut(),
             low_vram: params.low_vram,
+            rope_freq_base: params.rope_freq_base,
+            rope_freq_scale: params.rope_freq_scale,
         }
     }
 }
@@ -95,6 +99,8 @@ impl From<llama_context_params> for ContextParams {
             use_mmap: params.use_mmap,
             embedding: params.embedding,
             low_vram: params.low_vram,
+            rope_freq_base: params.rope_freq_base,
+            rope_freq_scale: params.rope_freq_scale,
         }
     }
 }

--- a/crates/llm-chain-llama/src/executor.rs
+++ b/crates/llm-chain-llama/src/executor.rs
@@ -30,7 +30,7 @@ macro_rules! bail {
 
 macro_rules! must_send {
     ($sender:expr, $val:expr) => {
-        if $sender.send($val).await.is_err() {
+        if $sender.send($val).is_err() {
             panic!("unable to send message");
         }
     };
@@ -169,11 +169,7 @@ impl Executor {
                     if n_used >= tokenized_input.len() && stop_sequence_i == 0 {
                         let str_output = context.llama_token_to_str(&embd[n_used]);
                         // XXX: make into chat if chat
-                        if sender
-                            .send(StreamSegment::Content(str_output))
-                            .await
-                            .is_err()
-                        {
+                        if sender.send(StreamSegment::Content(str_output)).is_err() {
                             panic!("Failed to send");
                         }
                     }

--- a/crates/llm-chain-llama/src/executor.rs
+++ b/crates/llm-chain-llama/src/executor.rs
@@ -203,7 +203,7 @@ impl ExecutorTrait for Executor {
             context: Arc::new(Mutex::new(LLamaContext::from_file_and_params(
                 &model_path,
                 Some(&context_params),
-            ))),
+            )?)),
             options,
             context_params,
         })

--- a/crates/llm-chain/src/output/mod.rs
+++ b/crates/llm-chain/src/output/mod.rs
@@ -45,7 +45,7 @@ impl Output {
     }
 
     /// Creates a new `Stream` output along with a sender to produce data.
-    pub fn new_stream() -> (mpsc::Sender<StreamSegment>, Self) {
+    pub fn new_stream() -> (mpsc::UnboundedSender<StreamSegment>, Self) {
         let (sender, stream) = OutputStream::new();
 
         (sender, Output::Stream(stream))


### PR DESCRIPTION
Updated llama.cpp (twice), only things that needed to be changed were adding some fields to `ContextParams`.

`llama_init_from_file` returns a nullptr if it fails which includes if the file is not found, but the rust code just silently ignores it and then only segfaults when it starts to run the model. Now it checks for nullptr and returns a `Result`.

When I used `llama.cpp` it would sometimes freeze the whole thread when the LLM made a lot of text. This was because the `mpsc` was set to have a limit of 100 segments but when the LLM is accelerated a lot like by CUBLAS it produces tokens faster than they are processed and fills up the buffer, which then gets deadlocked or something on `.send()` method (inside the library, not the user code). I replaced the `mpsc::channel(100)` with `mpsc::unbounded_channel()` so it can handle unlimited but if that is a performance concern maybe increase 100 to 1000 or something.

So far it works fine for running 33B Vicuna at least on my end.