### PR TITLE
Mock LLM driver

### DIFF
--- a/crates/llm-chain-mock/Cargo.toml
+++ b/crates/llm-chain-mock/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "llm-chain-mock"
+version = "0.12.3"
+edition = "2021"
+description = "Use `llm-chain` with a mock backend. Useful for testing."
+license = "MIT"
+keywords = ["llm", "langchain", "chain"]
+categories = ["science"]
+authors = ["Shing Lyu <shing.lyu@gmail.com>"]
+repository = "https://github.com/sobelio/llm-chain/"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1.68"
+llm-chain = { path = "../llm-chain", version = "0.12.3", default-features = false }
+thiserror = "1.0.40"
+
+[dev-dependencies]
+tokio = { version = "1.28.2", features = ["macros", "rt"] }

--- a/crates/llm-chain-mock/README.md
+++ b/crates/llm-chain-mock/README.md
@@ -1,0 +1,5 @@
+# llm-chain-mock
+
+Mock LLM driver. Echos your prompt and options to you for easy debugging.
+
+Running a real LLM locally or use a paid API is costly. For quick testing and debugging, this mock driver simulates a real LLM but is much faster and cheaper to run.

--- a/crates/llm-chain-mock/examples/simple.rs
+++ b/crates/llm-chain-mock/examples/simple.rs
@@ -1,0 +1,41 @@
+use llm_chain::executor;
+use llm_chain::options;
+use llm_chain::options::{ModelRef, Options};
+use std::{env::args, error::Error};
+
+use llm_chain::{prompt::Data, traits::Executor};
+
+extern crate llm_chain_mock;
+
+// TODO: fix the documentation
+/// This example demonstrates how to use the llm-chain-local crate to generate text using a model.
+///
+/// Usage: cargo run --release --package llm-chain-local --example simple model_type path/to/model
+///
+/// For example, if the model is a LLaMA-type model located at "/models/llama"
+/// cargo run --release --package llm-chain-local --example simple llama /models/llama
+///
+/// An optional third argument can be used to customize the prompt passed to the model.
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let raw_args: Vec<String> = args().collect();
+    let args = match &raw_args.len() {
+      3 => (raw_args[1].as_str(), raw_args[2].as_str(), "Rust is a cool programming language because"),
+      4 => (raw_args[1].as_str(), raw_args[2].as_str(), raw_args[3].as_str()),
+      _ => panic!("Usage: cargo run --release --example inference <model type> <path to model> <optional prompt>")
+    };
+
+    let model_type = args.0;
+    let model_path = args.1;
+    let prompt = args.2;
+
+    let exec = executor!(
+        mock
+    )?;
+    let res = exec
+        .execute(Options::empty(), &Data::Text(String::from(prompt)))
+        .await?;
+
+    println!("{}", res);
+    Ok(())
+}

--- a/crates/llm-chain-mock/examples/simple.rs
+++ b/crates/llm-chain-mock/examples/simple.rs
@@ -1,37 +1,25 @@
 use llm_chain::executor;
-use llm_chain::options;
-use llm_chain::options::{ModelRef, Options};
+use llm_chain::options::Options;
 use std::{env::args, error::Error};
 
 use llm_chain::{prompt::Data, traits::Executor};
 
 extern crate llm_chain_mock;
 
-// TODO: fix the documentation
-/// This example demonstrates how to use the llm-chain-local crate to generate text using a model.
+/// This example demonstrates how to use the llm-chain-mock crate to generate text using a mock model.
 ///
-/// Usage: cargo run --release --package llm-chain-local --example simple model_type path/to/model
+/// Usage: cargo run --release --package llm-chain-mock --example simple
 ///
-/// For example, if the model is a LLaMA-type model located at "/models/llama"
-/// cargo run --release --package llm-chain-local --example simple llama /models/llama
-///
-/// An optional third argument can be used to customize the prompt passed to the model.
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn Error>> {
     let raw_args: Vec<String> = args().collect();
-    let args = match &raw_args.len() {
-      3 => (raw_args[1].as_str(), raw_args[2].as_str(), "Rust is a cool programming language because"),
-      4 => (raw_args[1].as_str(), raw_args[2].as_str(), raw_args[3].as_str()),
-      _ => panic!("Usage: cargo run --release --example inference <model type> <path to model> <optional prompt>")
+    let prompt = match &raw_args.len() {
+      1 => "Rust is a cool programming language because",
+      2 => raw_args[1].as_str(),
+      _ => panic!("Usage: cargo run --release --example simple")
     };
 
-    let model_type = args.0;
-    let model_path = args.1;
-    let prompt = args.2;
-
-    let exec = executor!(
-        mock
-    )?;
+    let exec = executor!(mock)?;
     let res = exec
         .execute(Options::empty(), &Data::Text(String::from(prompt)))
         .await?;

--- a/crates/llm-chain-mock/src/executor.rs
+++ b/crates/llm-chain-mock/src/executor.rs
@@ -1,33 +1,16 @@
 use async_trait::async_trait;
-use llm_chain::options;
-use llm_chain::options::{options_from_env, Opt, OptDiscriminants, Options, OptionsCascade};
+use llm_chain::options::Options;
 use llm_chain::output::Output;
 use llm_chain::prompt::Prompt;
 use llm_chain::tokens::{
     PromptTokensError, TokenCollection, TokenCount, Tokenizer, TokenizerError,
 };
 use llm_chain::traits::{ExecutorCreationError, ExecutorError};
-use thiserror::Error;
 
 /// Executor is responsible for running the LLM and managing its context.
 pub struct Executor {
+    #[allow(dead_code)]
     options: Options,
-}
-
-// TODO: cleanup
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("an invalid token was encountered during tokenization")]
-    /// During tokenization, one of the produced tokens was invalid / zero.
-    TokenizationFailed,
-    #[error("the context window is full")]
-    /// The context window for the model is full.
-    ContextFull,
-    #[error("reached end of text")]
-    /// The model has produced an end of text token, signalling that it thinks that the text should end here.
-    ///
-    /// Note that this error *can* be ignored and inference can continue, but the results are not guaranteed to be sensical.
-    EndOfText,
 }
 
 #[async_trait]
@@ -35,12 +18,11 @@ impl llm_chain::traits::Executor for Executor {
     type StepTokenizer<'a> = MockTokenizer;
     
     fn new_with_options(options: Options) -> Result<Self, ExecutorCreationError> {
-        Ok(Executor { options })
+        Ok(Executor { options: options })
     }
 
     async fn execute(&self, options: &Options, prompt: &Prompt) -> Result<Output, ExecutorError> {
-        // TODO: print options1
-        let mut output = format!( "As a mock large language model, I'm here to help you debug. I have received your prompt: \"{prompt}\".");
+        let output = format!( "As a mock large language model, I'm here to help you debug. I have received your prompt: \"{prompt}\" with options \"{options:?}\"");
         Ok(Output::new_immediate(Prompt::text(output)))
     }
 
@@ -49,11 +31,26 @@ impl llm_chain::traits::Executor for Executor {
         options: &Options,
         prompt: &Prompt,
     ) -> Result<TokenCount, PromptTokensError> {
-        unimplemented!();
+                let tokenizer = self.get_tokenizer(options)?;
+        let input = prompt.to_text();
+        let mut tokens_used = tokenizer
+            .tokenize_str(&input)
+            .map_err(|_e| PromptTokensError::UnableToCompute)?
+            .len() as i32;
+        let answer_prefix = self.answer_prefix(prompt);
+        if let Some(prefix) = answer_prefix {
+            let answer_used = tokenizer
+                .tokenize_str(&prefix)
+                .map_err(|_e| PromptTokensError::UnableToCompute)?
+                .len() as i32;
+            tokens_used += answer_used
+        }
+        let max_tokens = self.max_tokens_allowed(options);
+        Ok(TokenCount::new(max_tokens, tokens_used))
     }
 
     fn max_tokens_allowed(&self, _: &Options) -> i32 {
-        unimplemented!();
+        i32::MAX
     }
 
     fn answer_prefix(&self, _prompt: &Prompt) -> Option<String> {
@@ -61,24 +58,45 @@ impl llm_chain::traits::Executor for Executor {
     }
 
     fn get_tokenizer(&self, _: &Options) -> Result<Self::StepTokenizer<'_>, TokenizerError> {
-        unimplemented!();
+        Ok(MockTokenizer::new(self))
     }
 }
 
 pub struct MockTokenizer {}
 
 impl MockTokenizer {
-    pub fn new(executor: Executor) -> Self {
+    pub fn new(_executor: &Executor) -> Self {
         MockTokenizer {}
     }
 }
 
 impl Tokenizer for MockTokenizer {
     fn tokenize_str(&self, doc: &str) -> Result<TokenCollection, TokenizerError> {
-        unimplemented!()
+        let tokens: Vec<i32> = doc.as_bytes().to_vec().into_iter().map(|c| c as i32).collect();
+        Ok(tokens.into())
     }
 
     fn to_string(&self, tokens: TokenCollection) -> Result<String, TokenizerError> {
-        unimplemented!()
+        let bytes : Vec<u8> = tokens.as_i32().unwrap().into_iter().map(|c| c as u8).collect();
+        let doc = String::from_utf8(bytes).unwrap();
+        Ok(doc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llm_chain::traits::Executor;
+    #[test]
+    fn test_mock_tokenizer() {
+        let executor: crate::Executor = Executor::new_with_options(Options::empty().clone()).unwrap();
+        let tokenizer = executor.get_tokenizer(&executor.options).unwrap();
+        let tokens = tokenizer
+            .tokenize_str("Héllo world") //Notice that the UTF8 character translates to x3 i32s
+            .expect("failed to tokenize");
+        println!("{:?}", tokens);
+        assert_eq!(tokens.len(), 13);
+        let doc = tokenizer.to_string(tokens).expect("failed to convert back to string");
+        assert_eq!(doc, "Héllo world");
     }
 }

--- a/crates/llm-chain-mock/src/executor.rs
+++ b/crates/llm-chain-mock/src/executor.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+use llm_chain::options;
+use llm_chain::options::{options_from_env, Opt, OptDiscriminants, Options, OptionsCascade};
+use llm_chain::output::Output;
+use llm_chain::prompt::Prompt;
+use llm_chain::tokens::{
+    PromptTokensError, TokenCollection, TokenCount, Tokenizer, TokenizerError,
+};
+use llm_chain::traits::{ExecutorCreationError, ExecutorError};
+use thiserror::Error;
+
+/// Executor is responsible for running the LLM and managing its context.
+pub struct Executor {
+    options: Options,
+}
+
+// TODO: cleanup
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("an invalid token was encountered during tokenization")]
+    /// During tokenization, one of the produced tokens was invalid / zero.
+    TokenizationFailed,
+    #[error("the context window is full")]
+    /// The context window for the model is full.
+    ContextFull,
+    #[error("reached end of text")]
+    /// The model has produced an end of text token, signalling that it thinks that the text should end here.
+    ///
+    /// Note that this error *can* be ignored and inference can continue, but the results are not guaranteed to be sensical.
+    EndOfText,
+}
+
+#[async_trait]
+impl llm_chain::traits::Executor for Executor {
+    type StepTokenizer<'a> = MockTokenizer;
+    
+    fn new_with_options(options: Options) -> Result<Self, ExecutorCreationError> {
+        Ok(Executor { options })
+    }
+
+    async fn execute(&self, options: &Options, prompt: &Prompt) -> Result<Output, ExecutorError> {
+        // TODO: print options1
+        let mut output = format!( "As a mock large language model, I'm here to help you debug. I have received your prompt: \"{prompt}\".");
+        Ok(Output::new_immediate(Prompt::text(output)))
+    }
+
+    fn tokens_used(
+        &self,
+        options: &Options,
+        prompt: &Prompt,
+    ) -> Result<TokenCount, PromptTokensError> {
+        unimplemented!();
+    }
+
+    fn max_tokens_allowed(&self, _: &Options) -> i32 {
+        unimplemented!();
+    }
+
+    fn answer_prefix(&self, _prompt: &Prompt) -> Option<String> {
+        None
+    }
+
+    fn get_tokenizer(&self, _: &Options) -> Result<Self::StepTokenizer<'_>, TokenizerError> {
+        unimplemented!();
+    }
+}
+
+pub struct MockTokenizer {}
+
+impl MockTokenizer {
+    pub fn new(executor: Executor) -> Self {
+        MockTokenizer {}
+    }
+}
+
+impl Tokenizer for MockTokenizer {
+    fn tokenize_str(&self, doc: &str) -> Result<TokenCollection, TokenizerError> {
+        unimplemented!()
+    }
+
+    fn to_string(&self, tokens: TokenCollection) -> Result<String, TokenizerError> {
+        unimplemented!()
+    }
+}

--- a/crates/llm-chain-mock/src/lib.rs
+++ b/crates/llm-chain-mock/src/lib.rs
@@ -1,0 +1,2 @@
+mod executor;
+pub use executor::Executor;

--- a/crates/llm-chain/src/executor.rs
+++ b/crates/llm-chain/src/executor.rs
@@ -68,4 +68,8 @@ macro_rules! executor {
         use llm_chain::traits::Executor;
         llm_chain_local::Executor::new_with_options($options)
     }};
+    (mock) => {{
+        use llm_chain::traits::Executor;
+        llm_chain_mock::Executor::new()
+    }};
 }

--- a/crates/llm-chain/src/tokens.rs
+++ b/crates/llm-chain/src/tokens.rs
@@ -225,6 +225,7 @@ impl Token {
 ///
 /// `TokenCollection` can hold a collection of `i32` or `usize` tokens,
 /// ensuring type safety and efficient storage.
+#[derive(Debug)]
 pub struct TokenCollection(TokenCollectionImpl);
 
 /// The internal enum representation of `TokenCollection`.
@@ -232,6 +233,7 @@ pub struct TokenCollection(TokenCollectionImpl);
 /// This enum holds the actual data for a `TokenCollection` instance,
 /// allowing us to differentiate between the two types of collections
 /// (`i32` and `usize`) in a type-safe manner.
+#[derive(Debug)]
 enum TokenCollectionImpl {
     /// A token collection of `i32`
     I32(Vec<i32>),


### PR DESCRIPTION
Running a real LLM locally or use a paid API is costly. For quick testing and debugging, this mock driver simulates a real LLM but is much faster and cheaper to run.

This implements a LLM executor that only echos your prompt and options back.