### PR TITLE
make project buildable

### DIFF
--- a/crates/llm-chain-milvus/src/lib.rs
+++ b/crates/llm-chain-milvus/src/lib.rs
@@ -228,7 +228,8 @@ where
                                     serde_json::from_str(&val[0])
                                         .map_err(errors::MilvusError::Serde)?;
 
-                                let metadata: Option<M> = payload
+                                let _metadata: Option<String> = payload // XXX: temp fix since the
+                                                                       // var is not used rn
                                     .get(&self.metadata_payload_key)
                                     .unwrap()
                                     .clone()


### PR DESCRIPTION
Set an unused variable to another type just to make the project build not fail