### PR TITLE
stop llama executor blocking

### DIFF
--- a/crates/llm-chain-llama/src/executor.rs
+++ b/crates/llm-chain-llama/src/executor.rs
@@ -59,9 +59,8 @@ impl Executor {
         let context_size = context_params.n_ctx as usize;
         let answer_prefix = self.answer_prefix(&input.prompt);
         tokio::task::spawn_blocking(move || {
-            async move {
                 let context_size = context_size;
-                let context = context.lock().await;
+                let context = context.blocking_lock();
                 let tokenized_stop_prompt = tokenize(
                     &context,
                     input
@@ -189,11 +188,7 @@ impl Executor {
                 {
                     panic!("Failed to send");
                 }
-            }
-        })
-        .await
-        .unwrap()
-        .await;
+        });//JoinHandle is dropped? not sure how this works
 
         output
     }


### PR DESCRIPTION
If I understand correctly:

Before, the `spawn_blocking` was actually returning another function that was async which would then get awaited which undoes the whole purpose of the `spawn_blocking`.

The async doesn't work that well since it doesn't have any `await`s other than the one locking the mutex, and I couldn't figure out how to get that to work in `spawn_blocking` so now it's changed to `blocking_lock`. 

Also now join handle doesn't get awaited so if the thread panics it doesn't really handle it (I think the mutex lock can also get messed up with a panicked thread?), I don't know the proper way do deal with that.
