### PR TITLE
chore: add flag to save bindings to src directory

### DIFF
--- a/crates/llm-chain-llama-sys/README.md
+++ b/crates/llm-chain-llama-sys/README.md
@@ -19,3 +19,11 @@ To update the llama.cpp submodule, run the following command:
 ```console
 $ git submodule update --remote --merge llama.cpp
 ```
+Then to save the generated bindings run the build and set the environment
+variable `LLAMA_SAVE_BINDINGS` to `true`:
+
+```console
+$ env LLAMA_SAVE_BINDINGS=true cargo build --release
+```
+
+And then check-in the generated bindings in `src/bindings.rs`.

--- a/crates/llm-chain-llama-sys/build.rs
+++ b/crates/llm-chain-llama-sys/build.rs
@@ -49,9 +49,15 @@ fn main() {
                 let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
                 b.write_to_file(out_path.join("bindings.rs"))
                     .expect("Couldn't write bindings!");
-                let out_path = PathBuf::from("src");
-                b.write_to_file(out_path.join("bindings.rs"))
-                    .expect("Couldn't write binding to src directorys!");
+
+                let save_bindings = env::var("LLAMA_SAVE_BINDINGS")
+                    .map(|value| value == "true")
+                    .unwrap_or(false);
+                if save_bindings {
+                    let out_path = PathBuf::from("src");
+                    b.write_to_file(out_path.join("bindings.rs"))
+                        .expect("Couldn't write binding to src directorys!");
+                }
             }
             Err(e) => {
                 println!("cargo:warning=Unable to generate bindings: {}", e);


### PR DESCRIPTION
This commit adds a flag that can be used to save the generated bindings to the src directory instead of always saving them.

The motivation for this is one might not want to save the bindings on every build which is kind of annoying (sorry about this).