### PR TITLE
Fix CUDA build for llm-chain-llama-sys

### DIFF
--- a/crates/llm-chain-llama-sys/Cargo.toml
+++ b/crates/llm-chain-llama-sys/Cargo.toml
@@ -18,6 +18,7 @@ readme = "README.md"
 
 [build-dependencies]
 bindgen = "0.66"
+cfg-if = "1"
 
 [features]
 cuda = []

--- a/crates/llm-chain-llama-sys/build.rs
+++ b/crates/llm-chain-llama-sys/build.rs
@@ -24,6 +24,21 @@ fn main() {
 
     // Check if CUDA is enabled for cuBlAS
     let cuda_enabled = env::var("CARGO_FEATURE_CUDA").is_ok();
+    if cuda_enabled {
+        println!("cargo:rustc-link-lib=cublas");
+        println!("cargo:rustc-link-lib=cudart");
+        println!("cargo:rustc-link-lib=cublasLt");
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "windows")] {
+                let cuda_path = PathBuf::from(env::var("CUDA_PATH").unwrap()).join("lib/x64");
+                println!("cargo:rustc-link-search={}", cuda_path.display());
+            } else {
+                println!("cargo:rustc-link-lib=culibos");
+                println!("cargo:rustc-link-search=/usr/local/cuda/lib64");
+                println!("cargo:rustc-link-search=/opt/cuda/lib64");
+            }
+        }
+    }
 
     if env::var("LLAMA_DONT_GENERATE_BINDINGS").is_ok() {
         let _: u64 = std::fs::copy(


### PR DESCRIPTION
This fixes the build when attempting to build llm-chain-llama-sys with CUDA enabled (by setting `CARGO_FEATURE_CUDA`). 

Without this PR, builds fail with errors similar to https://github.com/ggerganov/llama.cpp/issues/1728

I spent some time coming up with a solution that just worked on my machine before reading the comment at the top of the file which references https://github.com/tazz4843/whisper-rs/blob/master/sys/build.rs - which already had a cleaner cross-platform solution so I just copied that.

After this PR I can successfully build llm-chain-llama-sys with CUDA support (confirmed by setting the environment flag, and running a test app on my machine).