### PR TITLE
llama: replace cuda feature with env var

### DIFF
--- a/crates/llm-chain-llama-sys/Cargo.toml
+++ b/crates/llm-chain-llama-sys/Cargo.toml
@@ -18,6 +18,3 @@ readme = "README.md"
 
 [build-dependencies]
 bindgen = "0.66"
-
-[features]
-cuda = []

--- a/crates/llm-chain-llama/README.md
+++ b/crates/llm-chain-llama/README.md
@@ -14,3 +14,25 @@ LLM-Chain-LLaMa is packed with all the features you need to harness the full pot
 - Prompts for working with `instruct` models, empowering you to easily build virtual assistants amazing applications 🧙‍♂️
 
 So gear up and dive into the fantastic world of LLM-Chain-LLaMa! Let the power of LLaMa-style models propel your projects to the next level. Happy coding, and enjoy the ride! 🎉🥳
+
+
+## CUDA Support
+This requires the [CUDA toolkit] to be installed on the system. CUDA support can
+then be enabled by setting the following environment variables:
+* LLM_CHAIN_CUDA  
+This should be set to `true` to enable CUDA support.
+
+* LLM_CHAIN_CUDA_LIB_PATH  
+This should be set to the path of the CUDA library directory. For example, on
+Fedora, this could be `/usr/local/cuda-12.2/lib64`.
+
+
+Example of building with CUDA support:
+```console
+$ env LLM_CHAIN_CUDA_LIB_PATH=/usr/local/cuda-12.2/lib64 LLM_CHAIN_CUDA=true cargo b -vv
+```
+Using `-vv` will enable the output from llama.cpp build process to be displayed
+which can be useful for debugging build issues.
+
+[CUDA toolkit]: https://developer.nvidia.com/cuda-downloads
+```


### PR DESCRIPTION
This commit removes the `cuda` feature and replaces it with an
environment variable `LLM_CHAIN_CUDA`.It also adds an additional
environment variable `LLM_CHAIN_CUDA_LIB_PATH` which should be set to
the path of the CUDA library directory, and include link libraries
required for CUDA. Finally `-fPIC` is added to `CMAKE_CUDA_FLAGS`.
    
The motivation for this is that having the feature `cuda` was not
working as this will cause the build to fail if infact the CUDA
library is not installed. I think that this may not have been the case
with earlier versions of llama.cpp and perhaps why this was not an
issue before.
