### PR TITLE
docs: update llm-chain-llama-sys README.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3176,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"

--- a/crates/llm-chain-llama-sys/README.md
+++ b/crates/llm-chain-llama-sys/README.md
@@ -1,17 +1,17 @@
-# llama-sys
+# llm-chain-llama-sys
 
-llama-sys is a set of bindgen generated wrappers for llama.cpp. This crate provides a low-level interface to llama.cpp, allowing you to use it in your Rust projects. To use llama-sys, simply add the following to your Cargo.toml file:
+llm-chain-llama-sys is a set of bindgen generated wrappers for llama.cpp. This crate provides a low-level interface to llama.cpp, allowing you to use it in your Rust projects. To use llm-chain-llama-sys, simply add the following to your Cargo.toml file:
 
 ```toml
 [dependencies]
-llama-sys = "0.1.0"
+llm-chain-llama-sys = "0.1.0"
 ```
 
 ```rust
-use llama_sys::\*;
+use llm-chain-llama-sys::*;
 ```
 
-Note that llama-sys provides a lower-level interface than llm-chain-llama, and may be more difficult to use. However, if you need fine-grained control over llama.cpp, llama-sys is the way to go.
+Note that llm-chain-llama-sys provides a lower-level interface than llm-chain-llama, and may be more difficult to use. However, if you need fine-grained control over llama.cpp, llm-chain-llama-sys is the way to go.
 
 ## Updating llama.cpp submodule
 To update the llama.cpp submodule, run the following command:


### PR DESCRIPTION
This commit updates the README.md file for the llm-chain-llama-sys crate to reflect the correct name of the crate.

The motivation for this is that the readme on crates.io might be confusing at the moment:
https://crates.io/crates/llm-chain-llama-sys