### PR TITLE
Updated Docs, adding information about how use apikey without enviroment variable.

### DIFF
--- a/website/docs/getting-started-tutorial/02-generating-your-first-llm-output.md
+++ b/website/docs/getting-started-tutorial/02-generating-your-first-llm-output.md
@@ -45,5 +45,39 @@ One common issue you might encounter is forgetting to set the OpenAI API key. Ma
 ```bash
 export OPENAI_API_KEY="YOUR_OPEN_AI_KEY" # TIP: It stars with sk-
 ```
+If you don't want to set enviroment variable or want to multiple api-keys. Then you can use a different macro like this. 
+
+```rust
+use llm_chain::{executor, options, parameters, prompt};
+use tokio;
+
+// Declare an async main function
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a new ChatGPT executor
+    let options = options! {
+        ApiKey: "sk-proj-..."
+    };
+
+    let exec = executor!(chatgpt, options);
+    match exec {
+        Ok(exec) => {
+            
+            let res = prompt!(
+                "You are a robot assistant for making personalized greetings",
+                "Make a personalized greeting for Joe"
+            )
+            .run(&parameters!(), &exec) // ...and run it
+            .await?;
+            println!("{}", res);
+        }
+        Err(err) => panic!("Unable to create executor: {}", err),
+    }
+    // Create our step containing our prompt template
+
+    Ok(())
+}
+
+```
 
 In the next tutorial, we'll cover adding parameters to customize the LLM prompt to create more complicated interactions.


### PR DESCRIPTION
Good Morning Sir, 

I have been exploring the llm-chains project and, although I am new to Rust (just started learning about 4 hours ago through a tutorial), I found something that might be useful. I noticed that the current instructions suggest setting a single API key as an environment variable. However, I needed to implement a round-robin mechanism to use a cluster of API keys.

While reviewing the code, I found guidance on how to do this in the comment section, which was very helpful. I believe that adding this information to the documentation would make it more accessible to other users.

Therefore, I have updated the documentation to include instructions on setting up and using multiple API keys. I hope you find this addition valuable and that it will be merged into the main branch.

Thank you for your time and consideration.

Best regards,